### PR TITLE
Add primaryColor to Style

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,11 +17,11 @@ class MyApp extends StatelessWidget {
           title: 'macos_ui example',
           style: Style(
             brightness: Brightness.light,
-            accentColor: CupertinoColors.systemIndigo,
+            primaryColor: CupertinoColors.systemIndigo,
           ),
           darkStyle: Style(
             brightness: Brightness.dark,
-            accentColor: CupertinoColors.systemIndigo,
+            primaryColor: CupertinoColors.systemIndigo,
           ),
           themeMode: appTheme.mode,
           debugShowCheckedModeBanner: false, //yay!
@@ -43,7 +43,7 @@ class Demo extends StatelessWidget {
         child: Container(
           height: 50.0,
           width: 50.0,
-          color: context.theme.accentColor,
+          color: context.style.primaryColor,
         ),
       ),
     );

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -66,7 +66,7 @@ class Scaffold extends StatelessWidget {
   Widget build(BuildContext context) {
     debugCheckHasMacosTheme(context);
 
-    final style = context.theme;
+    final style = context.style;
     late Color bodyColor;
     late Color sidebarColor;
     late Color gripColor;

--- a/lib/src/macos_app.dart
+++ b/lib/src/macos_app.dart
@@ -52,7 +52,7 @@ class MacosApp extends StatefulWidget {
     this.builder,
     this.title = '',
     this.onGenerateTitle,
-    this.primaryColor,
+    this.color,
     this.locale,
     this.localizationsDelegates,
     this.localeListResolutionCallback,
@@ -85,7 +85,7 @@ class MacosApp extends StatefulWidget {
     this.builder,
     this.title = '',
     this.onGenerateTitle,
-    this.primaryColor,
+    this.color,
     this.locale,
     this.localizationsDelegates,
     this.localeListResolutionCallback,
@@ -170,7 +170,7 @@ class MacosApp extends StatefulWidget {
   final GenerateAppTitle? onGenerateTitle;
 
   /// {@macro flutter.widgets.widgetsApp.color}
-  final Color? primaryColor;
+  final Color? color;
 
   /// {@macro flutter.widgets.widgetsApp.locale}
   final Locale? locale;
@@ -329,7 +329,7 @@ class _MacosAppState extends State<MacosApp> {
   }
 
   Widget _buildApp(BuildContext context) {
-    final defaultColor = widget.primaryColor ?? CupertinoColors.systemBlue;
+    final defaultColor = widget.color ?? CupertinoColors.systemBlue;
     if (_usesRouter) {
       return c.CupertinoApp.router(
         key: GlobalObjectKey(this),

--- a/lib/src/styles/theme.dart
+++ b/lib/src/styles/theme.dart
@@ -32,8 +32,8 @@ class MacosTheme extends InheritedWidget {
 }
 
 extension themeContext on BuildContext {
-  Style get theme => MacosTheme.of(this);
-  Style? get maybeTheme => MacosTheme.maybeOf(this);
+  Style get style => MacosTheme.of(this);
+  Style? get maybeStyle => MacosTheme.maybeOf(this);
 }
 
 extension brightnessExtension on Brightness {
@@ -48,10 +48,13 @@ class Style with Diagnosticable {
   const Style({
     this.typography,
     this.brightness,
+    this.primaryColor,
     this.accentColor,
     this.animationCurve,
     this.mediumAnimationDuration,
   });
+
+  final CupertinoDynamicColor? primaryColor;
 
   final CupertinoDynamicColor? accentColor;
 
@@ -69,6 +72,7 @@ class Style with Diagnosticable {
       brightness: brightness,
       typography: Typography.defaultTypography(brightness: brightness)
           .copyWith(typography),
+      primaryColor: primaryColor ?? CupertinoColors.systemBlue,
       accentColor: accentColor ?? CupertinoColors.systemBlue,
       mediumAnimationDuration: Duration(milliseconds: 300),
       animationCurve: Curves.easeInOut,
@@ -90,6 +94,8 @@ class Style with Diagnosticable {
       animationCurve: other.animationCurve ?? animationCurve,
       mediumAnimationDuration:
           other.mediumAnimationDuration ?? mediumAnimationDuration,
+      primaryColor: other.primaryColor ?? primaryColor,
+      accentColor: other.accentColor ?? accentColor,
     );
   }
 
@@ -97,5 +103,7 @@ class Style with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(EnumProperty('brightness', brightness));
+    properties.add(EnumProperty('primaryColor', primaryColor));
+    properties.add(EnumProperty('accentColor', accentColor));
   }
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,7 +1,7 @@
 import 'package:macos_ui/macos_ui.dart';
 
 bool debugCheckHasMacosTheme(BuildContext context, [bool check = true]) {
-  final has = context.maybeTheme != null;
+  final has = context.maybeStyle != null;
   if (check)
     assert(
       has,


### PR DESCRIPTION
Renames MacosApp's primaryColor to simply "color" as a result. Also adds debug properties to Style for primaryColor and accentColor.