### PR TITLE
Add canvasColor to MacosThemeData and apply it to Scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.2.3]
+* Add `canvasColor` to `MacosThemeData`. `Scaffold` now uses this as its default background color.
+
 ## [0.2.2]
 * Add new `MacosColor` and `MacosColors` classes
 * Rename `colors.dart` to `macos_dynamic_color`

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.2.3"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -127,18 +127,14 @@ class _ScaffoldState extends State<Scaffold> {
           (widget.sidebar!.startWidth! <= widget.sidebar!.maxWidth!));
     }
     final MacosThemeData theme = MacosTheme.of(context);
-    late Color backgroundColor;
+    late Color backgroundColor = widget.backgroundColor ?? theme.canvasColor;
     late Color sidebarBackgroundColor;
     Color dividerColor = theme.dividerColor;
 
     if (!theme.brightness.isDark) {
-      backgroundColor =
-          widget.backgroundColor ?? CupertinoColors.systemBackground.color;
       sidebarBackgroundColor = widget.sidebar?.decoration?.color ??
           CupertinoColors.systemGrey6.color;
     } else {
-      backgroundColor = widget.backgroundColor ??
-          CupertinoColors.systemBackground.darkElevatedColor;
       sidebarBackgroundColor = widget.sidebar?.decoration?.color ??
           CupertinoColors.tertiarySystemBackground.darkColor;
     }

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -188,6 +188,7 @@ class MacosThemeData with Diagnosticable {
   factory MacosThemeData({
     Brightness? brightness,
     Color? primaryColor,
+    Color? canvasColor,
     Typography? typography,
     PushButtonThemeData? pushButtonTheme,
     Color? dividerColor,
@@ -201,6 +202,9 @@ class MacosThemeData with Diagnosticable {
     primaryColor ??= isDark
         ? CupertinoColors.activeBlue.darkColor
         : CupertinoColors.activeBlue.color;
+    canvasColor ??= isDark
+        ? CupertinoColors.systemBackground.darkElevatedColor
+        : CupertinoColors.systemBackground;
     typography ??= Typography(
       color: brightness == Brightness.light
           ? CupertinoColors.black
@@ -232,6 +236,7 @@ class MacosThemeData with Diagnosticable {
     return MacosThemeData.raw(
       brightness: _brightness,
       primaryColor: primaryColor,
+      canvasColor: canvasColor,
       typography: typography,
       pushButtonTheme: pushButtonTheme,
       dividerColor: dividerColor,
@@ -251,6 +256,7 @@ class MacosThemeData with Diagnosticable {
   const MacosThemeData.raw({
     required this.brightness,
     required this.primaryColor,
+    required this.canvasColor,
     required this.typography,
     required this.pushButtonTheme,
     required this.dividerColor,
@@ -289,6 +295,9 @@ class MacosThemeData with Diagnosticable {
   /// Defaults to [CupertinoColors.activeBlue].
   final Color primaryColor;
 
+  /// The default color of Scaffold backgrounds.
+  final Color canvasColor;
+
   /// The default text styling for this theme.
   final Typography typography;
 
@@ -319,6 +328,7 @@ class MacosThemeData with Diagnosticable {
       brightness: t < 0.5 ? a.brightness : b.brightness,
       dividerColor: Color.lerp(a.dividerColor, b.dividerColor, t)!,
       primaryColor: Color.lerp(a.primaryColor, b.primaryColor, t)!,
+      canvasColor: Color.lerp(a.primaryColor, b.primaryColor, t)!,
       typography: Typography.lerp(a.typography, b.typography, t),
       helpButtonTheme:
           HelpButtonThemeData.lerp(a.helpButtonTheme, b.helpButtonTheme, t),
@@ -335,6 +345,7 @@ class MacosThemeData with Diagnosticable {
   MacosThemeData copyWith({
     Brightness? brightness,
     Color? primaryColor,
+    Color? canvasColor,
     Typography? typography,
     PushButtonThemeData? pushButtonTheme,
     Color? dividerColor,
@@ -346,6 +357,7 @@ class MacosThemeData with Diagnosticable {
     return MacosThemeData.raw(
       brightness: brightness ?? this.brightness,
       primaryColor: primaryColor ?? this.primaryColor,
+      canvasColor: canvasColor ?? this.canvasColor,
       dividerColor: dividerColor ?? this.dividerColor,
       typography: typography ?? this.typography,
       pushButtonTheme: this.pushButtonTheme.copyWith(pushButtonTheme),
@@ -361,6 +373,7 @@ class MacosThemeData with Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(EnumProperty('brightness', brightness));
     properties.add(ColorProperty('primaryColor', primaryColor));
+    properties.add(ColorProperty('canvasColor', canvasColor));
     properties.add(ColorProperty('dividerColor', dividerColor));
     properties.add(DiagnosticsProperty<Typography>('typography', typography));
     properties.add(DiagnosticsProperty<PushButtonThemeData>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.2.2
+version: 0.2.3
 homepage: 'https://github.com/GroovinChip/macos_ui'
 
 environment:


### PR DESCRIPTION
This PR contains the following changes:
* Add `canvasColor` property to `MacosThemeData`
* Apply `canvasColor` to `Scaffold`
* The colors that `Scaffold` previously set for its `backgroundColor` is now set to `canvasColor` in `MacosThemeData`

Closes #116 

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
- [x] I have added/updated relevant documentation
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes
- [x] I have run `flutter pub publish --dry-run` and addressed any warnings