### PR TITLE
Colors update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ build/
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
+/example/detective_connect.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.4.1]
+* Update `MacosColors`
+
 ## [0.4.0]
 * Adds the `SidebarItem` widget
 * Fixes an alignment issue with `MacosTextField`

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+.fvm
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:example/pages/buttons.dart';
+import 'package:example/pages/colors_page.dart';
 import 'package:example/pages/fields.dart';
 import 'package:example/pages/indicators.dart';
 import 'package:flutter/material.dart';
@@ -53,7 +54,7 @@ class _DemoState extends State<Demo> {
     ButtonsPage(),
     IndicatorsPage(),
     FieldsPage(),
-    Text('Disclosure item 1'),
+    ColorsPage(),
     Text('Disclosure item 2'),
     Text('Disclosure item 3'),
     Text('Item after disclosure'),
@@ -97,7 +98,7 @@ class _DemoState extends State<Demo> {
                 disclosureItems: [
                   SidebarItem(
                     leading: Icon(CupertinoIcons.infinite),
-                    label: Text('Item 1'),
+                    label: Text('Colors'),
                   ),
                   SidebarItem(
                     leading: Icon(CupertinoIcons.heart),
@@ -120,6 +121,7 @@ class _DemoState extends State<Demo> {
               controller: scrollController,
               padding: EdgeInsets.all(20),
               child: IndexedStack(
+                alignment: Alignment.topCenter,
                 index: pageIndex,
                 children: pages,
               ),

--- a/example/lib/pages/colors_page.dart
+++ b/example/lib/pages/colors_page.dart
@@ -15,62 +15,7 @@ class _ColorsPageState extends State<ColorsPage> {
       children: [
         Wrap(
           spacing: 8.0,
-          runSpacing: 4.0,
-          children: [
-            MacosTooltip(
-              message: 'Label',
-              child: ColorBox(
-                color: MacosColors.labelColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Label Dark',
-              child: ColorBox(
-                color: MacosColors.labelColor.darkColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Secondary Label',
-              child: ColorBox(
-                color: MacosColors.secondaryLabelColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Secondary Label Dark',
-              child: ColorBox(
-                color: MacosColors.secondaryLabelColor.darkColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Tertiary Label',
-              child: ColorBox(
-                color: MacosColors.tertiaryLabelColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Tertiary Label Dark',
-              child: ColorBox(
-                color: MacosColors.tertiaryLabelColor.darkColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Quaternary Label',
-              child: ColorBox(
-                color: MacosColors.quaternaryLabelColor,
-              ),
-            ),
-            MacosTooltip(
-              message: 'Quaternary Label Dark',
-              child: ColorBox(
-                color: MacosColors.quaternaryLabelColor.darkColor,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 16.0),
-        Wrap(
-          spacing: 8.0,
-          runSpacing: 4.0,
+          runSpacing: 8.0,
           children: [
             MacosTooltip(
               message: 'System Red',
@@ -202,6 +147,163 @@ class _ColorsPageState extends State<ColorsPage> {
               message: 'System Gray Dark',
               child: ColorBox(
                 color: MacosColors.systemGrayColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Link',
+              child: ColorBox(
+                color: MacosColors.linkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Link Dark',
+              child: ColorBox(
+                color: MacosColors.linkColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Unemphasized Background',
+              child: ColorBox(
+                color: MacosColors.unemphasizedSelectedTextBackgroundColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Unemphasized Background Dark',
+              child: ColorBox(
+                color: MacosColors
+                    .unemphasizedSelectedTextBackgroundColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Background',
+              child: ColorBox(
+                color: MacosColors.controlBackgroundColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Background Dark',
+              child: ColorBox(
+                color: MacosColors.controlBackgroundColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control',
+              child: ColorBox(
+                color: MacosColors.controlColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Dark',
+              child: ColorBox(
+                color: MacosColors.controlColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Text',
+              child: ColorBox(
+                color: MacosColors.controlTextColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Text Dark',
+              child: ColorBox(
+                color: MacosColors.controlTextColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Text Disabled',
+              child: ColorBox(
+                color: MacosColors.disabledControlTextColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Control Text Disabled Dark',
+              child: ColorBox(
+                color: MacosColors.disabledControlTextColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Selected Control',
+              child: ColorBox(
+                color: MacosColors.selectedControlColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Selected Control Dark',
+              child: ColorBox(
+                color: MacosColors.selectedControlColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Selected Control Text',
+              child: ColorBox(
+                color: MacosColors.selectedControlTextColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Selected Control Text Dark',
+              child: ColorBox(
+                color: MacosColors.selectedControlTextColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Keyboard Focus Indicator',
+              child: ColorBox(
+                color: MacosColors.keyboardFocusIndicatorColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Keyboard Focus Indicator',
+              child: ColorBox(
+                color: MacosColors.keyboardFocusIndicatorColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Label',
+              child: ColorBox(
+                color: MacosColors.labelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Label Dark',
+              child: ColorBox(
+                color: MacosColors.labelColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Secondary Label',
+              child: ColorBox(
+                color: MacosColors.secondaryLabelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Secondary Label Dark',
+              child: ColorBox(
+                color: MacosColors.secondaryLabelColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Tertiary Label',
+              child: ColorBox(
+                color: MacosColors.tertiaryLabelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Tertiary Label Dark',
+              child: ColorBox(
+                color: MacosColors.tertiaryLabelColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Quaternary Label',
+              child: ColorBox(
+                color: MacosColors.quaternaryLabelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Quaternary Label Dark',
+              child: ColorBox(
+                color: MacosColors.quaternaryLabelColor.darkColor,
               ),
             ),
           ],

--- a/example/lib/pages/colors_page.dart
+++ b/example/lib/pages/colors_page.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:macos_ui/macos_ui.dart';
+
+class ColorsPage extends StatefulWidget {
+  ColorsPage({Key? key}) : super(key: key);
+
+  @override
+  _ColorsPageState createState() => _ColorsPageState();
+}
+
+class _ColorsPageState extends State<ColorsPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Wrap(
+          spacing: 8.0,
+          runSpacing: 4.0,
+          children: [
+            MacosTooltip(
+              message: 'Label',
+              child: ColorBox(
+                color: MacosColors.labelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Label Dark',
+              child: ColorBox(
+                color: MacosColors.labelColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Secondary Label',
+              child: ColorBox(
+                color: MacosColors.secondaryLabelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Secondary Label Dark',
+              child: ColorBox(
+                color: MacosColors.secondaryLabelColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Tertiary Label',
+              child: ColorBox(
+                color: MacosColors.tertiaryLabelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Tertiary Label Dark',
+              child: ColorBox(
+                color: MacosColors.tertiaryLabelColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Quaternary Label',
+              child: ColorBox(
+                color: MacosColors.quaternaryLabelColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'Quaternary Label Dark',
+              child: ColorBox(
+                color: MacosColors.quaternaryLabelColor.darkColor,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16.0),
+        Wrap(
+          spacing: 8.0,
+          runSpacing: 4.0,
+          children: [
+            MacosTooltip(
+              message: 'System Red',
+              child: ColorBox(
+                color: MacosColors.systemRedColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Red Dark',
+              child: ColorBox(
+                color: MacosColors.systemRedColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Green',
+              child: ColorBox(
+                color: MacosColors.systemGreenColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Green Dark',
+              child: ColorBox(
+                color: MacosColors.systemGreenColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Blue',
+              child: ColorBox(
+                color: MacosColors.systemBlueColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Blue Dark',
+              child: ColorBox(
+                color: MacosColors.systemBlueColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Orange',
+              child: ColorBox(
+                color: MacosColors.systemOrangeColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Orange Dark',
+              child: ColorBox(
+                color: MacosColors.systemOrangeColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Yellow',
+              child: ColorBox(
+                color: MacosColors.systemYellowColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Yellow Dark',
+              child: ColorBox(
+                color: MacosColors.systemYellowColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Brown',
+              child: ColorBox(
+                color: MacosColors.systemBrownColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Brown Dark',
+              child: ColorBox(
+                color: MacosColors.systemBrownColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Pink',
+              child: ColorBox(
+                color: MacosColors.systemPinkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Pink Dark',
+              child: ColorBox(
+                color: MacosColors.systemPinkColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Purple',
+              child: ColorBox(
+                color: MacosColors.systemPurpleColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Purple Dark',
+              child: ColorBox(
+                color: MacosColors.systemPurpleColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Teal',
+              child: ColorBox(
+                color: MacosColors.systemTealColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Teal Dark',
+              child: ColorBox(
+                color: MacosColors.systemTealColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Indigo',
+              child: ColorBox(
+                color: MacosColors.systemIndigoColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Indigo Dark',
+              child: ColorBox(
+                color: MacosColors.systemIndigoColor.darkColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Gray',
+              child: ColorBox(
+                color: MacosColors.systemGrayColor,
+              ),
+            ),
+            MacosTooltip(
+              message: 'System Gray Dark',
+              child: ColorBox(
+                color: MacosColors.systemGrayColor.darkColor,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class ColorBox extends StatelessWidget {
+  const ColorBox({
+    Key? key,
+    required this.color,
+  }) : super(key: key);
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return ColoredBox(
+      color: color,
+      child: SizedBox(
+        height: 50,
+        width: 50,
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -107,7 +107,8 @@ class MacosColors {
 
   /// A background for selected text in a non-key window or view.
   static const unemphasizedSelectedTextBackgroundColor = MacosColor(0xffDCDCDC);
-  static const unemphasizedSelectedTextBackgroundColorDark = MacosColor(0xff464646);
+  static const unemphasizedSelectedTextBackgroundColorDark =
+      MacosColor(0xff464646);
 
   /// Selected text in a non-key window or view.
   static const unemphasizedSelectedTextColor = MacosColors.white;
@@ -158,7 +159,8 @@ class MacosColors {
   /// The ring that appears around the currently focused control when using
   /// the keyboard for interface navigation.
   static const keyboardFocusIndicatorColor = Color.fromRGBO(0, 103, 244, 0.25);
-  static const keyboardFocusIndicatorColorDark = Color.fromRGBO(26, 169, 255, 0.3);
+  static const keyboardFocusIndicatorColorDark =
+      Color.fromRGBO(26, 169, 255, 0.3);
 
   /// The accent color selected by the user in system preferences.
   ///

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -106,7 +106,8 @@ class MacosColors {
   static const selectedTextBackgroundColor = MacosColor(0xff3f638b);
 
   /// A background for selected text in a non-key window or view.
-  static const unemphasizedSelectedTextBackgroundColor = MacosColor(0xff464646);
+  static const unemphasizedSelectedTextBackgroundColor = MacosColor(0xffDCDCDC);
+  static const unemphasizedSelectedTextBackgroundColorDark = MacosColor(0xff464646);
 
   /// Selected text in a non-key window or view.
   static const unemphasizedSelectedTextColor = MacosColors.white;
@@ -129,6 +130,8 @@ class MacosColors {
   static const alternatingContentBackgroundColor = MacosColor(0xff2e2c31);
 
   /// The color of a find indicator.
+  ///
+  /// Has no dark variant.
   static const findHighlightColor = MacosColor(0xffffff00);
 
   /// The surface of a control.
@@ -145,7 +148,8 @@ class MacosColors {
       Color.fromRGBO(255, 255, 255, 0.25);
 
   /// The surface of a selected control.
-  static const selectedControlColor = MacosColor(0xffddddde);
+  static const selectedControlColor = Color.fromRGBO(179, 215, 255, 1);
+  static const selectedControlColorDark = Color.fromRGBO(63, 99, 139, 1);
 
   /// The text of a selected control.
   static const selectedControlTextColor = MacosColor(0xffddddde);
@@ -153,10 +157,13 @@ class MacosColors {
 
   /// The ring that appears around the currently focused control when using
   /// the keyboard for interface navigation.
-  static const keyboardFocusIndicatorColor = MacosColor(0xff294a69);
+  static const keyboardFocusIndicatorColor = Color.fromRGBO(0, 103, 244, 0.25);
+  static const keyboardFocusIndicatorColorDark = Color.fromRGBO(26, 169, 255, 0.3);
 
   /// The accent color selected by the user in system preferences.
-  static const controlAccentColor = MacosColor(0xff007aff);
+  ///
+  /// No dark variant.
+  static const controlAccentColor = Color.fromRGBO(0, 122, 255, 1);
 
   static const appleBlue = MacosColor(0xff0433ff);
   static const appleBrown = MacosColor(0xffaa7942);

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -1,5 +1,7 @@
 import 'dart:ui';
 
+import 'package:macos_ui/src/library.dart';
+
 /// An immutable 32 bit color value in ARGB format.
 class MacosColor extends Color {
   /// Construct a color from the lower 32 bits of an [int].
@@ -19,56 +21,86 @@ class MacosColors {
   static const white = MacosColor(0xffffffff);
 
   /// The text of a label containing primary content.
-  static const labelColor = Color.fromRGBO(0, 0, 0, 0.85);
-  static const labelColorDark = Color.fromRGBO(255, 255, 255, 0.85);
+  static const labelColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 0, 0, 0.85),
+    darkColor: Color.fromRGBO(255, 255, 255, 0.85),
+  );
 
   /// The text of a label of lesser importance than a primary label, such as
   /// a label used to represent a subheading or additional information.
-  static const secondaryLabelColor = Color.fromRGBO(0, 0, 0, 0.5);
-  static const secondaryLabelColorDark = Color.fromRGBO(255, 255, 255, 0.55);
+  static const secondaryLabelColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 0, 0, 0.5),
+    darkColor: Color.fromRGBO(255, 255, 255, 0.55),
+  );
 
   /// The text of a label of lesser importance than a secondary label such as
   /// a label used to represent disabled text.
-  static const tertiaryLabelColor = Color.fromRGBO(0, 0, 0, 0.26);
-  static const tertiaryLabelColorDark = Color.fromRGBO(255, 255, 255, 0.26);
+  static const tertiaryLabelColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 0, 0, 0.26),
+    darkColor: Color.fromRGBO(255, 255, 255, 0.26),
+  );
 
   /// The text of a label of lesser importance than a tertiary label such as
   /// watermark text.
-  static const quaternaryLabelColor = Color.fromRGBO(0, 0, 0, 0.1);
-  static const quaternaryLabelColorDark = Color.fromRGBO(255, 255, 255, 0.1);
+  static const quaternaryLabelColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 0, 0, 0.1),
+    darkColor: Color.fromRGBO(255, 255, 255, 0.1),
+  );
 
-  static const systemRedColor = MacosColor(0xffFF3B30);
-  static const systemRedColorDark = MacosColor(0xffFF453A);
+  static const systemRedColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffFF3B30),
+    darkColor: MacosColor(0xffFF453A),
+  );
 
-  static const systemGreenColor = MacosColor(0xff34C759);
-  static const systemGreenColorDark = MacosColor(0xff30D158);
+  static const systemGreenColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xff34C759),
+    darkColor: MacosColor(0xff30D158),
+  );
 
-  static const systemBlueColor = MacosColor(0xff007AFF);
-  static const systemBlueColorDark = MacosColor(0xff0A84FF);
+  static const systemBlueColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xff007AFF),
+    darkColor: MacosColor(0xff0A84FF),
+  );
 
-  static const systemOrangeColor = MacosColor(0xffFF9500);
-  static const systemOrangeColorDark = MacosColor(0xffFF9F0A);
+  static const systemOrangeColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffFF9500),
+    darkColor: MacosColor(0xffFF9F0A),
+  );
 
-  static const systemYellowColor = MacosColor(0xffFF9F0A);
-  static const systemYellowColorDark = MacosColor(0xffFFD60A);
+  static const systemYellowColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffFF9F0A),
+    darkColor: MacosColor(0xffFFD60A),
+  );
 
-  static const systemBrownColor = MacosColor(0xffA2845E);
-  static const systemBrownColorDark = MacosColor(0xffAC8E68);
+  static const systemBrownColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffA2845E),
+    darkColor: MacosColor(0xffAC8E68),
+  );
 
-  static const systemPinkColor = MacosColor(0xffFF2D55);
-  static const systemPinkColorDark = MacosColor(0xffFF375F);
+  static const systemPinkColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffFF2D55),
+    darkColor: MacosColor(0xffFF375F),
+  );
 
-  static const systemPurpleColor = MacosColor(0xffAF52DE);
-  static const systemPurpleColorDark = MacosColor(0xffBF5AF2);
+  static const systemPurpleColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffAF52DE),
+    darkColor: MacosColor(0xffBF5AF2),
+  );
 
-  static const systemTealColor = MacosColor(0xff55BEF0);
-  static const systemTealColorDark = MacosColor(0xff5AC8F5);
+  static const systemTealColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xff55BEF0),
+    darkColor: MacosColor(0xff5AC8F5),
+  );
 
-  static const systemIndigoColor = MacosColor(0xff5856D6);
-  static const systemIndigoColorDark = MacosColor(0xff5E5CE6);
+  static const systemIndigoColor = CupertinoDynamicColor.withBrightness(
+      color: MacosColor(0xff5856D6),
+      darkColor: MacosColor(0xff5E5CE6),
+  );
 
-  static const systemGrayColor = MacosColor(0xff8E8E93);
-  static const systemGrayColorDark = MacosColor(0xff98989D);
+  static const systemGrayColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xff8E8E93),
+    darkColor: MacosColor(0xff98989D),
+  );
 
   /// A link to other content.
   static const linkColor = MacosColor(0xff0068DA);

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -93,8 +93,8 @@ class MacosColors {
   );
 
   static const systemIndigoColor = CupertinoDynamicColor.withBrightness(
-      color: MacosColor(0xff5856D6),
-      darkColor: MacosColor(0xff5E5CE6),
+    color: MacosColor(0xff5856D6),
+    darkColor: MacosColor(0xff5E5CE6),
   );
 
   static const systemGrayColor = CupertinoDynamicColor.withBrightness(
@@ -103,11 +103,14 @@ class MacosColors {
   );
 
   /// A link to other content.
-  static const linkColor = MacosColor(0xff0068DA);
-  static const linkColorDark = Color.fromRGBO(65, 156, 255, 1);
+  static const linkColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xff0068DA),
+    darkColor: Color.fromRGBO(65, 156, 255, 1),
+  );
 
   /// A placeholder string in a control or text view.
   static const placeholderTextColor = MacosColor(0xff737473);
+
   static const windowFrameColor = MacosColor(0xffddddde);
 
   /// The text of a selected menu.
@@ -138,9 +141,11 @@ class MacosColors {
   static const selectedTextBackgroundColor = MacosColor(0xff3f638b);
 
   /// A background for selected text in a non-key window or view.
-  static const unemphasizedSelectedTextBackgroundColor = MacosColor(0xffDCDCDC);
-  static const unemphasizedSelectedTextBackgroundColorDark =
-      MacosColor(0xff464646);
+  static const unemphasizedSelectedTextBackgroundColor =
+      CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffDCDCDC),
+    darkColor: MacosColor(0xff464646),
+  );
 
   /// Selected text in a non-key window or view.
   static const unemphasizedSelectedTextColor = MacosColors.white;
@@ -152,14 +157,17 @@ class MacosColors {
   static const underPageBackgroundColor = MacosColor(0xff282828);
 
   /// The background of a large interface element, such as a browser or table.
-  static const controlBackgroundColor = MacosColor(0xffFFFFFF);
-  static const controlBackgroundColorDark = MacosColor(0xff1E1E1E);
+  static const controlBackgroundColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffFFFFFF),
+    darkColor: MacosColor(0xff1E1E1E),
+  );
 
   static const selectedControlBackgroundColor = MacosColor(0xff0058d0);
 
   /// The selected content in a non-key window or view.
   static const unemphasizedSelectedContentBackgroundColor =
       MacosColor(0xff464646);
+
   static const alternatingContentBackgroundColor = MacosColor(0xff2e2c31);
 
   /// The color of a find indicator.
@@ -168,31 +176,42 @@ class MacosColors {
   static const findHighlightColor = MacosColor(0xffffff00);
 
   /// The surface of a control.
-  static const controlColor = MacosColor(0xffFFFFFF);
-  static const controlColorDark = Color.fromRGBO(255, 255, 255, 0.25);
+  static const controlColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffFFFFFF),
+    darkColor: Color.fromRGBO(255, 255, 255, 0.25),
+  );
 
   /// The text of a control that isn’t disabled.
-  static const controlTextColor = Color.fromRGBO(0, 0, 0, 0.85);
-  static const controlTextColorDark = MacosColor(0xffddddde);
+  static const controlTextColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 0, 0, 0.85),
+    darkColor: MacosColor(0xffddddde),
+  );
 
   /// The text of a control that’s disabled.
-  static const disabledControlTextColor = Color.fromRGBO(0, 0, 0, 0.25);
-  static const disabledControlTextColorDark =
-      Color.fromRGBO(255, 255, 255, 0.25);
+  static const disabledControlTextColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 0, 0, 0.25),
+    darkColor: Color.fromRGBO(255, 255, 255, 0.25),
+  );
 
   /// The surface of a selected control.
-  static const selectedControlColor = Color.fromRGBO(179, 215, 255, 1);
-  static const selectedControlColorDark = Color.fromRGBO(63, 99, 139, 1);
+  static const selectedControlColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(179, 215, 255, 1),
+    darkColor: Color.fromRGBO(63, 99, 139, 1),
+  );
 
   /// The text of a selected control.
-  static const selectedControlTextColor = MacosColor(0xffddddde);
-  static const disabledControlColor = MacosColor(0xff5a585c);
+  static const selectedControlTextColor = CupertinoDynamicColor.withBrightness(
+    color: MacosColor(0xffddddde),
+    darkColor: MacosColor(0xff5a585c),
+  );
 
   /// The ring that appears around the currently focused control when using
   /// the keyboard for interface navigation.
-  static const keyboardFocusIndicatorColor = Color.fromRGBO(0, 103, 244, 0.25);
-  static const keyboardFocusIndicatorColorDark =
-      Color.fromRGBO(26, 169, 255, 0.3);
+  static const keyboardFocusIndicatorColor =
+      CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(0, 103, 244, 0.25),
+    darkColor: Color.fromRGBO(26, 169, 255, 0.3),
+  );
 
   /// The accent color selected by the user in system preferences.
   ///

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -17,50 +17,147 @@ class MacosColors {
   static const Color transparent = MacosColor(0x00000000);
   static const black = MacosColor(0xff000000);
   static const white = MacosColor(0xffffffff);
-  static const labelColor = MacosColors.white;
-  static const secondaryLabelColor = MacosColor(0xff9c9b9e);
-  static const tertiaryLabelColor = MacosColor(0xff5a585c);
-  static const quaternaryLabelColor = MacosColor(0xff39373c);
-  static const systemRedColor = MacosColor(0xffff453a);
-  static const systemGreenColor = MacosColor(0xff32d74b);
-  static const systemBlueColor = MacosColor(0xff0a84ff);
-  static const systemOrangeColor = MacosColor(0xffff9f0a);
-  static const systemYellowColor = MacosColor(0xffffd60a);
-  static const systemBrownColor = MacosColor(0xffac8e68);
-  static const systemPinkColor = MacosColor(0xffff375f);
-  static const systemPurpleColor = MacosColor(0xffbf5af2);
-  static const systemTealColor = MacosColor(0xff5ac8f5);
-  static const systemIndigoColor = MacosColor(0xff5e5ce6);
-  static const systemGrayColor = MacosColor(0xff9c9b9e);
-  static const linkColor = MacosColor(0xff419cff);
+
+  /// The text of a label containing primary content.
+  static const labelColor = Color.fromRGBO(0, 0, 0, 0.85);
+  static const labelColorDark = Color.fromRGBO(255, 255, 255, 0.85);
+
+  /// The text of a label of lesser importance than a primary label, such as
+  /// a label used to represent a subheading or additional information.
+  static const secondaryLabelColor = Color.fromRGBO(0, 0, 0, 0.5);
+  static const secondaryLabelColorDark = Color.fromRGBO(255, 255, 255, 0.55);
+
+  /// The text of a label of lesser importance than a secondary label such as
+  /// a label used to represent disabled text.
+  static const tertiaryLabelColor = Color.fromRGBO(0, 0, 0, 0.26);
+  static const tertiaryLabelColorDark = Color.fromRGBO(255, 255, 255, 0.26);
+
+  /// The text of a label of lesser importance than a tertiary label such as
+  /// watermark text.
+  static const quaternaryLabelColor = Color.fromRGBO(0, 0, 0, 0.1);
+  static const quaternaryLabelColorDark = Color.fromRGBO(255, 255, 255, 0.1);
+
+  static const systemRedColor = MacosColor(0xffFF3B30);
+  static const systemRedColorDark = MacosColor(0xffFF453A);
+
+  static const systemGreenColor = MacosColor(0xff34C759);
+  static const systemGreenColorDark = MacosColor(0xff30D158);
+
+  static const systemBlueColor = MacosColor(0xff007AFF);
+  static const systemBlueColorDark = MacosColor(0xff0A84FF);
+
+  static const systemOrangeColor = MacosColor(0xffFF9500);
+  static const systemOrangeColorDark = MacosColor(0xffFF9F0A);
+
+  static const systemYellowColor = MacosColor(0xffFF9F0A);
+  static const systemYellowColorDark = MacosColor(0xffFFD60A);
+
+  static const systemBrownColor = MacosColor(0xffA2845E);
+  static const systemBrownColorDark = MacosColor(0xffAC8E68);
+
+  static const systemPinkColor = MacosColor(0xffFF2D55);
+  static const systemPinkColorDark = MacosColor(0xffFF375F);
+
+  static const systemPurpleColor = MacosColor(0xffAF52DE);
+  static const systemPurpleColorDark = MacosColor(0xffBF5AF2);
+
+  static const systemTealColor = MacosColor(0xff55BEF0);
+  static const systemTealColorDark = MacosColor(0xff5AC8F5);
+
+  static const systemIndigoColor = MacosColor(0xff5856D6);
+  static const systemIndigoColorDark = MacosColor(0xff5E5CE6);
+
+  static const systemGrayColor = MacosColor(0xff8E8E93);
+  static const systemGrayColorDark = MacosColor(0xff98989D);
+
+  /// A link to other content.
+  static const linkColor = MacosColor(0xff0068DA);
+  static const linkColorDark = Color.fromRGBO(65, 156, 255, 1);
+
+  /// A placeholder string in a control or text view.
   static const placeholderTextColor = MacosColor(0xff737473);
   static const windowFrameColor = MacosColor(0xffddddde);
+
+  /// The text of a selected menu.
   static const selectedMenuItemTextColor = MacosColor(0xfffeffff);
+
+  /// The text on a selected surface in a list or table.
   static const alternateSelectedControlTextColor = MacosColors.white;
+
+  ///	The text of a header cell in a table.
   static const headerTextColor = MacosColors.white;
+
+  ///	A separator between different sections of content.
   static const separatorColor = MacosColor(0xff39373c);
+
+  ///	The gridlines of an interface element such as a table.
   static const gridColor = MacosColor(0xff39373c);
+
+  ///	The text in a document.
   static const textColor = MacosColors.white;
+
+  ///	Text background.
   static const textBackgroundColor = MacosColor(0xff1e1e1e);
+
+  ///	Selected text.
   static const selectedTextColor = MacosColors.white;
+
+  ///	The background of selected text.
   static const selectedTextBackgroundColor = MacosColor(0xff3f638b);
+
+  /// A background for selected text in a non-key window or view.
   static const unemphasizedSelectedTextBackgroundColor = MacosColor(0xff464646);
+
+  /// Selected text in a non-key window or view.
   static const unemphasizedSelectedTextColor = MacosColors.white;
+
+  /// The background of a window.
   static const windowBackgroundColor = MacosColor(0xff3b373d);
+
+  /// The background behind a document's content.
   static const underPageBackgroundColor = MacosColor(0xff282828);
-  static const controlBackgroundColor = MacosColor(0xff1e1e1e);
+
+  /// The background of a large interface element, such as a browser or table.
+  static const controlBackgroundColor = MacosColor(0xffFFFFFF);
+  static const controlBackgroundColorDark = MacosColor(0xff1E1E1E);
+
   static const selectedControlBackgroundColor = MacosColor(0xff0058d0);
+
+  /// The selected content in a non-key window or view.
   static const unemphasizedSelectedContentBackgroundColor =
       MacosColor(0xff464646);
   static const alternatingContentBackgroundColor = MacosColor(0xff2e2c31);
+
+  /// The color of a find indicator.
   static const findHighlightColor = MacosColor(0xffffff00);
-  static const controlColor = MacosColor(0xff5a585c);
-  static const controlTextColor = MacosColor(0xffddddde);
+
+  /// The surface of a control.
+  static const controlColor = MacosColor(0xffFFFFFF);
+  static const controlColorDark = Color.fromRGBO(255, 255, 255, 0.25);
+
+  /// The text of a control that isn’t disabled.
+  static const controlTextColor = Color.fromRGBO(0, 0, 0, 0.85);
+  static const controlTextColorDark = MacosColor(0xffddddde);
+
+  /// The text of a control that’s disabled.
+  static const disabledControlTextColor = Color.fromRGBO(0, 0, 0, 0.25);
+  static const disabledControlTextColorDark =
+      Color.fromRGBO(255, 255, 255, 0.25);
+
+  /// The surface of a selected control.
   static const selectedControlColor = MacosColor(0xffddddde);
+
+  /// The text of a selected control.
   static const selectedControlTextColor = MacosColor(0xffddddde);
   static const disabledControlColor = MacosColor(0xff5a585c);
+
+  /// The ring that appears around the currently focused control when using
+  /// the keyboard for interface navigation.
   static const keyboardFocusIndicatorColor = MacosColor(0xff294a69);
+
+  /// The accent color selected by the user in system preferences.
   static const controlAccentColor = MacosColor(0xff007aff);
+
   static const appleBlue = MacosColor(0xff0433ff);
   static const appleBrown = MacosColor(0xffaa7942);
   static const appleCyan = MacosColor(0xff00fdff);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -112,7 +112,7 @@ packages:
       name: dart_code_metrics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.2"
+    version: "3.3.4"
   dart_style:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.4.0
+version: 0.4.1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  dart_code_metrics: ^3.2.3
+  dart_code_metrics: ^3.3.3
 
 flutter:
   fonts:


### PR DESCRIPTION
This PR updates the `MacosColors` class with dark/light variants of some colors. Additionally, it contains documentation that describes the rather inscrutably-named colors (I blame Apple).

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->