### PR TITLE
Sidebar bottom item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.4.2]
+* Add `bottom` Item to `Sidebar`
+
 ## [0.4.1]
 * Update `MacosColors`
 * Fix `Label` alignment

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -75,6 +75,15 @@ class _DemoState extends State<Demo> {
       ),
       sidebar: Sidebar(
         minWidth: 200,
+        bottom: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Row(
+            children: [
+              Icon(CupertinoIcons.profile_circled),
+              Text('Tim Apple'),
+            ],
+          ),
+        ),
         builder: (context, controller) {
           return SidebarItems(
             currentIndex: pageIndex,

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -180,6 +180,8 @@ class _MacosScaffoldState extends State<MacosScaffold> {
                           ),
                         ),
                       ),
+                      if(widget.sidebar?.bottom != null)
+                        widget.sidebar!.bottom!,
                     ],
                   ),
                 ),

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -180,7 +180,7 @@ class _MacosScaffoldState extends State<MacosScaffold> {
                           ),
                         ),
                       ),
-                      if(widget.sidebar?.bottom != null)
+                      if (widget.sidebar?.bottom != null)
                         widget.sidebar!.bottom!,
                     ],
                   ),

--- a/lib/src/layout/sidebar.dart
+++ b/lib/src/layout/sidebar.dart
@@ -16,6 +16,7 @@ class Sidebar {
     this.startWidth,
     this.padding = EdgeInsets.zero,
     this.scaffoldBreakpoint = 556.0,
+    this.bottom,
   });
 
   /// The builder that creates a child to display in this widget, which will
@@ -73,4 +74,7 @@ class Sidebar {
 
   /// Specifies the width of the scaffold at which this [ResizablePane] will be hidden.
   final double scaffoldBreakpoint;
+
+  /// Widget that should be displayed at the Bottom of the Sidebar
+  final Widget? bottom;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.4.1
+version: 0.4.2
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
Add the option to provide a `bottom` Widget to the `Sidebar` Widget.

This closes #130 


<img width="912" alt="image" src="https://user-images.githubusercontent.com/7288963/121043446-ed0c9e80-c7b4-11eb-8139-423e2cb82b50.png">

<img width="912" alt="image" src="https://user-images.githubusercontent.com/7288963/121043416-e2520980-c7b4-11eb-9d81-da1384757a42.png">


## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could