### PR TITLE
Removed maxHeight constraint from MacosAlertDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.5.2]
+* Fixes maximum height issue with `MacosAlertDialog`
+
 ## [0.5.1]
 * Adds `suppress` widget parameter to `MacosAlertDialog`
 

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -97,10 +97,7 @@ class MacosAlertDialog extends StatelessWidget {
         borderRadius: BorderRadius.circular(7.0),
       ),
       child: ConstrainedBox(
-        constraints: BoxConstraints(
-          maxHeight: 300,
-          maxWidth: 260,
-        ),
+        constraints: BoxConstraints(maxWidth: 260),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.5.1
+version: 0.5.2
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
Removes maxHeight constraint from MacosAlertDialog. Fixes #137

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->