### PR TITLE
Dialog Design Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.6.0]
+* Improved `MacosAlertDialog` design
+* Added `showMacosAlertDialog` to display a `MacosAlertDialog` with standard macOS animations and behaviour.
+  
 ## [0.5.2]
 * Fixes maximum height issue with `MacosAlertDialog`
 

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -16,7 +16,7 @@ class _DialogsPageState extends State<DialogsPage> {
         PushButton(
           buttonSize: ButtonSize.large,
           child: Text('Show Alert Dialog 1'),
-          onPressed: () => showDialog(
+          onPressed: () => showMacosAlertDialog(
             context: context,
             builder: (_) => MacosAlertDialog(
               appIcon: FlutterLogo(
@@ -41,7 +41,7 @@ class _DialogsPageState extends State<DialogsPage> {
         PushButton(
           buttonSize: ButtonSize.large,
           child: Text('Show Alert Dialog 2'),
-          onPressed: () => showDialog(
+          onPressed: () => showMacosAlertDialog(
             context: context,
             builder: (_) => MacosAlertDialog(
               appIcon: FlutterLogo(
@@ -82,7 +82,7 @@ class _DialogsPageState extends State<DialogsPage> {
         PushButton(
           buttonSize: ButtonSize.large,
           child: Text('Show Alert Dialog 3'),
-          onPressed: () => showDialog(
+          onPressed: () => showMacosAlertDialog(
             context: context,
             builder: (_) => MacosAlertDialog(
               appIcon: FlutterLogo(
@@ -123,7 +123,7 @@ class _DialogsPageState extends State<DialogsPage> {
         PushButton(
           buttonSize: ButtonSize.large,
           child: Text('Show Alert Dialog 4'),
-          onPressed: () => showDialog(
+          onPressed: () => showMacosAlertDialog(
             context: context,
             builder: (_) => MacosAlertDialog(
               appIcon: FlutterLogo(

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -32,7 +32,7 @@ class _DialogsPageState extends State<DialogsPage> {
               primaryButton: PushButton(
                 buttonSize: ButtonSize.large,
                 child: Text('Primary'),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
             ),
           ),
@@ -58,7 +58,7 @@ class _DialogsPageState extends State<DialogsPage> {
               primaryButton: PushButton(
                 buttonSize: ButtonSize.large,
                 child: Text('Primary'),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
               secondaryButton: PushButton(
                 buttonSize: ButtonSize.large,
@@ -73,7 +73,7 @@ class _DialogsPageState extends State<DialogsPage> {
                         : MacosColors.controlTextColor,
                   ),
                 ),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
             ),
           ),
@@ -99,7 +99,7 @@ class _DialogsPageState extends State<DialogsPage> {
               primaryButton: PushButton(
                 buttonSize: ButtonSize.large,
                 child: Text('Primary'),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
               secondaryButton: PushButton(
                 buttonSize: ButtonSize.large,
@@ -114,7 +114,7 @@ class _DialogsPageState extends State<DialogsPage> {
                         : MacosColors.controlTextColor,
                   ),
                 ),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
             ),
           ),
@@ -141,7 +141,7 @@ class _DialogsPageState extends State<DialogsPage> {
               primaryButton: PushButton(
                 buttonSize: ButtonSize.large,
                 child: Text('Primary'),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
               secondaryButton: PushButton(
                 buttonSize: ButtonSize.large,
@@ -158,7 +158,7 @@ class _DialogsPageState extends State<DialogsPage> {
                     ),
                   ),
                 ),
-                onPressed: () {},
+                onPressed: Navigator.of(context).pop,
               ),
               suppress: DoNotNotifyRow(),
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   nested:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.2"
+    version: "0.6.0"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -226,3 +226,29 @@ class MacosAlertDialog extends StatelessWidget {
     );
   }
 }
+
+Future<T?> showMacosAlertDialog<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool barrierDismissible = true,
+  Color? barrierColor,
+  String? barrierLabel,
+  bool useSafeArea = true,
+  bool useRootNavigator = true,
+  RouteSettings? routeSettings,
+}) {
+  barrierColor ??= (MacosTheme.brightnessOf(context).isDark
+          ? MacosColors.controlBackgroundColor.darkColor
+          : MacosColors.controlBackgroundColor)
+      .withOpacity(0.6);
+  return showDialog<T>(
+    context: context,
+    builder: builder,
+    barrierDismissible: barrierDismissible,
+    barrierColor: barrierColor,
+    barrierLabel: barrierLabel,
+    useSafeArea: useSafeArea,
+    useRootNavigator: useRootNavigator,
+    routeSettings: routeSettings,
+  );
+}

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -9,6 +9,29 @@ const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 ///
 /// A [MacosAlertDialog] must display an [appIcon], [title], [message],
 /// and [primaryButton].
+///
+/// To display a [MacosAlertDialog] call [showMacosAlertDialog].
+/// ```dart
+/// showMacosAlertDialog(
+///    context: context,
+///    builder: (_) => MacosAlertDialog(
+///     appIcon: FlutterLogo(
+///       size: 56,
+///     ),
+///     title: Text(
+///       'Alert Dialog with Primary Action',
+///     ),
+///     message: Text(
+///       'This is an alert dialog with a primary action and no secondary action',
+///     ),
+///     primaryButton: PushButton(
+///       buttonSize: ButtonSize.large,
+///       child: Text('Primary'),
+///       onPressed: Navigator.of(context).pop,
+///     ),
+///   ),
+/// ),
+/// ```
 class MacosAlertDialog extends StatelessWidget {
   /// Builds a macOS-style Alert Dialog
   const MacosAlertDialog({
@@ -74,10 +97,10 @@ class MacosAlertDialog extends StatelessWidget {
   ///       mainAxisAlignment: MainAxisAlignment.center,
   ///       children: [
   ///         MacosCheckbox(
-  ///           value: suppress,
-  ///           onChanged: (value) {
-  ///             setState(() => suppress = value);
-  ///           },
+  //// value: suppress,
+  //// onChanged: (value) {
+  ////   setState(() => suppress = value);
+  //// },
   ///         ),
   ///         const SizedBox(width: 8),
   ///         Text('Don\'t ask again'),

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -137,6 +137,7 @@ class MacosAlertDialog extends StatelessWidget {
         borderRadius: _kDialogBorderRadius,
       ),
       child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
         decoration: BoxDecoration(
           border: Border.all(
             width: 2,
@@ -169,70 +170,59 @@ class MacosAlertDialog extends StatelessWidget {
               const SizedBox(height: 28),
               DefaultTextStyle(
                 style: MacosTheme.of(context).typography.headline,
+                textAlign: TextAlign.center,
                 child: title,
               ),
               const SizedBox(height: 16),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: DefaultTextStyle(
-                  textAlign: TextAlign.center,
-                  style: MacosTheme.of(context).typography.headline,
-                  child: message,
-                ),
+              DefaultTextStyle(
+                textAlign: TextAlign.center,
+                style: MacosTheme.of(context).typography.headline,
+                child: message,
               ),
               const SizedBox(height: 18),
               if (secondaryButton == null) ...[
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: Row(
+                Row(
+                  children: [
+                    Expanded(
+                      child: primaryButton,
+                    ),
+                  ],
+                ),
+              ] else ...[
+                if (horizontalActions!) ...[
+                  Row(
                     children: [
+                      if (secondaryButton != null) ...[
+                        Expanded(
+                          child: secondaryButton!,
+                        ),
+                        const SizedBox(width: 8.0),
+                      ],
                       Expanded(
                         child: primaryButton,
                       ),
                     ],
                   ),
-                ),
-              ] else ...[
-                if (horizontalActions!) ...[
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                    child: Row(
-                      children: [
-                        if (secondaryButton != null) ...[
-                          Expanded(
-                            child: secondaryButton!,
-                          ),
-                          const SizedBox(width: 8.0),
-                        ],
-                        Expanded(
-                          child: primaryButton,
-                        ),
-                      ],
-                    ),
-                  ),
                 ] else ...[
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
+                  Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(child: primaryButton),
+                        ],
+                      ),
+                      const SizedBox(height: 8.0),
+                      if (secondaryButton != null) ...[
                         Row(
                           children: [
-                            Expanded(child: primaryButton),
+                            Expanded(
+                              child: secondaryButton!,
+                            ),
                           ],
                         ),
-                        const SizedBox(height: 8.0),
-                        if (secondaryButton != null) ...[
-                          Row(
-                            children: [
-                              Expanded(
-                                child: secondaryButton!,
-                              ),
-                            ],
-                          ),
-                        ],
                       ],
-                    ),
+                    ],
                   ),
                 ],
               ],

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:macos_ui/macos_ui.dart';
+
+const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 
 /// A macOS-style AlertDialog.
 ///
@@ -89,64 +92,76 @@ class MacosAlertDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final brightness = MacosTheme.brightnessOf(context);
+
+    final outerBorderColor = brightness.resolve(
+      Colors.black.withOpacity(0.23),
+      Colors.black.withOpacity(0.76),
+    );
+
+    final innerBorderColor = brightness.resolve(
+      Colors.white.withOpacity(0.45),
+      Colors.white.withOpacity(0.15),
+    );
+
     return Dialog(
-      backgroundColor: MacosTheme.brightnessOf(context).isDark
-          ? MacosColors.controlBackgroundColor.darkColor
-          : MacosColors.controlBackgroundColor,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(7.0),
+      backgroundColor: brightness.resolve(
+        CupertinoColors.systemGrey6.color,
+        MacosColors.controlBackgroundColor.darkColor,
       ),
-      child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: 260),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const SizedBox(height: 28),
-            ConstrainedBox(
-              constraints: BoxConstraints(
-                maxHeight: 56,
-                maxWidth: 56,
+      shape: RoundedRectangleBorder(
+        borderRadius: _kDialogBorderRadius,
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(
+            width: 2,
+            color: innerBorderColor,
+          ),
+          borderRadius: _kDialogBorderRadius,
+        ),
+        foregroundDecoration: BoxDecoration(
+          border: Border.all(
+            width: 1,
+            color: outerBorderColor,
+          ),
+          borderRadius: _kDialogBorderRadius,
+        ),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: 260,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 28),
+              ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxHeight: 56,
+                  maxWidth: 56,
+                ),
+                child: appIcon,
               ),
-              child: appIcon,
-            ),
-            const SizedBox(height: 28),
-            DefaultTextStyle(
-              style: MacosTheme.of(context).typography.headline,
-              child: title,
-            ),
-            const SizedBox(height: 16),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: DefaultTextStyle(
-                textAlign: TextAlign.center,
+              const SizedBox(height: 28),
+              DefaultTextStyle(
                 style: MacosTheme.of(context).typography.headline,
-                child: message,
+                child: title,
               ),
-            ),
-            const SizedBox(height: 12),
-            if (secondaryButton == null) ...[
+              const SizedBox(height: 16),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: primaryButton,
-                    ),
-                  ],
+                child: DefaultTextStyle(
+                  textAlign: TextAlign.center,
+                  style: MacosTheme.of(context).typography.headline,
+                  child: message,
                 ),
               ),
-            ] else ...[
-              if (horizontalActions!) ...[
+              const SizedBox(height: 18),
+              if (secondaryButton == null) ...[
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16.0),
                   child: Row(
                     children: [
-                      if (secondaryButton != null) ...[
-                        Expanded(
-                          child: secondaryButton!,
-                        ),
-                        const SizedBox(width: 8.0),
-                      ],
                       Expanded(
                         child: primaryButton,
                       ),
@@ -154,39 +169,58 @@ class MacosAlertDialog extends StatelessWidget {
                   ),
                 ),
               ] else ...[
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(child: primaryButton),
+                if (horizontalActions!) ...[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Row(
+                      children: [
+                        if (secondaryButton != null) ...[
+                          Expanded(
+                            child: secondaryButton!,
+                          ),
+                          const SizedBox(width: 8.0),
                         ],
-                      ),
-                      const SizedBox(height: 8.0),
-                      if (secondaryButton != null) ...[
-                        Row(
-                          children: [
-                            Expanded(
-                              child: secondaryButton!,
-                            ),
-                          ],
+                        Expanded(
+                          child: primaryButton,
                         ),
                       ],
-                    ],
+                    ),
                   ),
-                ),
+                ] else ...[
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(child: primaryButton),
+                          ],
+                        ),
+                        const SizedBox(height: 8.0),
+                        if (secondaryButton != null) ...[
+                          Row(
+                            children: [
+                              Expanded(
+                                child: secondaryButton!,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
               ],
+              const SizedBox(height: 16),
+              if (suppress != null)
+                DefaultTextStyle(
+                  style: MacosTheme.of(context).typography.headline,
+                  child: suppress!,
+                ),
+              const SizedBox(height: 16),
             ],
-            const SizedBox(height: 16),
-            if (suppress != null)
-              DefaultTextStyle(
-                style: MacosTheme.of(context).typography.headline,
-                child: suppress!,
-              ),
-            const SizedBox(height: 16),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/library.dart';
 
 const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 
@@ -97,10 +98,10 @@ class MacosAlertDialog extends StatelessWidget {
   ///       mainAxisAlignment: MainAxisAlignment.center,
   ///       children: [
   ///         MacosCheckbox(
-  //// value: suppress,
-  //// onChanged: (value) {
-  ////   setState(() => suppress = value);
-  //// },
+  ///  value: suppress,
+  ///  onChanged: (value) {
+  ///    setState(() => suppress = value);
+  ///  },
   ///         ),
   ///         const SizedBox(width: 8),
   ///         Text('Don\'t ask again'),
@@ -116,6 +117,7 @@ class MacosAlertDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasMacosTheme(context));
     final brightness = MacosTheme.brightnessOf(context);
 
     final outerBorderColor = brightness.resolve(
@@ -251,10 +253,11 @@ Future<T?> showMacosAlertDialog<T>({
   bool useRootNavigator = true,
   RouteSettings? routeSettings,
 }) {
-  barrierColor ??= (MacosTheme.brightnessOf(context).isDark
-          ? MacosColors.controlBackgroundColor.darkColor
-          : MacosColors.controlBackgroundColor)
-      .withOpacity(0.6);
+  barrierColor ??= MacosDynamicColor.resolve(
+    MacosColors.controlBackgroundColor,
+    context,
+  ).withOpacity(0.6);
+
   return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(
     _MacosAlertDialogRoute<T>(
       settings: routeSettings,

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -300,7 +300,10 @@ class _MacosAlertDialogRoute<T> extends PopupRoute<T> {
   final Color? _barrierColor;
 
   @override
-  Duration get transitionDuration => const Duration(milliseconds: 450);
+  Curve get barrierCurve => Curves.linear;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 4050);
 
   @override
   Duration get reverseTransitionDuration => const Duration(milliseconds: 120);

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -303,7 +303,7 @@ class _MacosAlertDialogRoute<T> extends PopupRoute<T> {
   Curve get barrierCurve => Curves.linear;
 
   @override
-  Duration get transitionDuration => const Duration(milliseconds: 4050);
+  Duration get transitionDuration => const Duration(milliseconds: 450);
 
   @override
   Duration get reverseTransitionDuration => const Duration(milliseconds: 120);

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -393,4 +393,9 @@ class MacosThemeData with Diagnosticable {
 extension BrightnessX on Brightness {
   /// Check if the brightness is dark or not.
   bool get isDark => this == Brightness.dark;
+
+  T resolve<T>(T light, T dark) {
+    if (isDark) return dark;
+    return light;
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.1"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -171,7 +171,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   package_config:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.5.2
+version: 0.6.0
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
## Description
Until now, MacosAlertDialog had quite a few problems which made it feel very different from NSAlert.

1. MacosAlertDialog was flat and lacked borders.
2. Wrong spacing between description and actions.
3. MacosAlertDialog uses the material dialog entrance and exit animations.
4. Wrong default barrier color (changes with brightness).
5. Wrong border radius.
6. Wrong background color on light theme.
7. Dismissible barriers by default.

This PR addresses all of these issues.

### Before:

<img width="571" alt="Screenshot 2021-06-21 at 23 02 21" src="https://user-images.githubusercontent.com/63465656/122833357-be2e1680-d2e4-11eb-90ee-c96bd47d0459.png">

### After:

<img width="510" alt="Screenshot 2021-06-21 at 23 01 32" src="https://user-images.githubusercontent.com/63465656/122833302-a22a7500-d2e4-11eb-80fd-2f0c3c4cef65.png">


## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->