### PR TITLE
Mouse Cursor

### DIFF
--- a/lib/src/buttons/back_button.dart
+++ b/lib/src/buttons/back_button.dart
@@ -119,8 +119,10 @@ class _MacosBackButtonState extends State<MacosBackButton>
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasMacosTheme(context));
+    final MacosThemeData theme = MacosTheme.of(context);
     final bool enabled = widget.enabled;
-    final brightness = MacosTheme.of(context).brightness;
+    final Brightness brightness = theme.brightness;
     final iconColor = brightness == Brightness.dark
         ? CupertinoColors.white
         : CupertinoColors.black;
@@ -134,7 +136,7 @@ class _MacosBackButtonState extends State<MacosBackButton>
     }
 
     return MouseRegion(
-      cursor: SystemMouseCursors.click,
+      cursor: theme.mouseCursor,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTapDown: enabled ? _handleTapDown : null,

--- a/lib/src/buttons/checkbox.dart
+++ b/lib/src/buttons/checkbox.dart
@@ -84,52 +84,55 @@ class MacosCheckbox extends StatelessWidget {
     assert(debugCheckHasMacosTheme(context));
     final MacosThemeData theme = MacosTheme.of(context);
     bool isLight = !theme.brightness.isDark;
-    return GestureDetector(
-      onTap: () {
-        if (value == null || value == false) {
-          onChanged?.call(true);
-        } else {
-          onChanged?.call(false);
-        }
-      },
-      child: Semantics(
-        // value == true because [value] can be null
-        checked: value == true,
-        label: semanticLabel,
-        child: Container(
-          height: size,
-          width: size,
-          alignment: Alignment.center,
-          decoration: isDisabled || value == null || value == true
-              ? BoxDecoration(
-                  color: MacosDynamicColor.resolve(
-                    isDisabled
-                        ? disabledColor
-                        : activeColor ?? theme.primaryColor,
-                    context,
-                  ),
-                  borderRadius: BorderRadius.circular(4.0),
-                )
-              : BoxDecoration(
-                  color: isLight ? null : CupertinoColors.tertiaryLabel,
-                  border: Border.all(
-                    style: isLight ? BorderStyle.solid : BorderStyle.none,
-                    width: 0.5,
+    return MouseRegion(
+      cursor: theme.mouseCursor,
+      child: GestureDetector(
+        onTap: () {
+          if (value == null || value == false) {
+            onChanged?.call(true);
+          } else {
+            onChanged?.call(false);
+          }
+        },
+        child: Semantics(
+          // value == true because [value] can be null
+          checked: value == true,
+          label: semanticLabel,
+          child: Container(
+            height: size,
+            width: size,
+            alignment: Alignment.center,
+            decoration: isDisabled || value == null || value == true
+                ? BoxDecoration(
                     color: MacosDynamicColor.resolve(
-                      offBorderColor,
+                      isDisabled
+                          ? disabledColor
+                          : activeColor ?? theme.primaryColor,
                       context,
                     ),
+                    borderRadius: BorderRadius.circular(4.0),
+                  )
+                : BoxDecoration(
+                    color: isLight ? null : CupertinoColors.tertiaryLabel,
+                    border: Border.all(
+                      style: isLight ? BorderStyle.solid : BorderStyle.none,
+                      width: 0.5,
+                      color: MacosDynamicColor.resolve(
+                        offBorderColor,
+                        context,
+                      ),
+                    ),
+                    borderRadius: BorderRadius.circular(4.0),
                   ),
-                  borderRadius: BorderRadius.circular(4.0),
-                ),
-          child: Icon(
-            isDisabled || value == false
-                ? null
-                : isMixed
-                    ? CupertinoIcons.minus
-                    : CupertinoIcons.check_mark,
-            color: CupertinoColors.white,
-            size: (size - 3).clamp(0, size),
+            child: Icon(
+              isDisabled || value == false
+                  ? null
+                  : isMixed
+                      ? CupertinoIcons.minus
+                      : CupertinoIcons.check_mark,
+              color: CupertinoColors.white,
+              size: (size - 3).clamp(0, size),
+            ),
           ),
         ),
       ),

--- a/lib/src/buttons/help_button.dart
+++ b/lib/src/buttons/help_button.dart
@@ -153,6 +153,7 @@ class _HelpButtonState extends State<HelpButton>
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasMacosTheme(context));
     final bool enabled = widget.enabled;
     final MacosThemeData theme = MacosTheme.of(context);
     final Color backgroundColor = MacosDynamicColor.resolve(
@@ -172,7 +173,7 @@ class _HelpButtonState extends State<HelpButton>
             : Color.fromRGBO(0, 0, 0, 0.25);
 
     return MouseRegion(
-      cursor: SystemMouseCursors.click,
+      cursor: theme.mouseCursor,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTapDown: enabled ? _handleTapDown : null,

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -183,6 +183,7 @@ class _MacosIconButtonState extends State<MacosIconButton>
 
   @override
   Widget build(BuildContext context) {
+    assert(debugCheckHasMacosTheme(context));
     final bool enabled = widget.enabled;
     final MacosThemeData theme = MacosTheme.of(context);
 
@@ -202,7 +203,7 @@ class _MacosIconButtonState extends State<MacosIconButton>
     }
 
     return MouseRegion(
-      cursor: SystemMouseCursors.click,
+      cursor: theme.mouseCursor,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTapDown: enabled ? _handleTapDown : null,

--- a/lib/src/buttons/push_button.dart
+++ b/lib/src/buttons/push_button.dart
@@ -238,7 +238,7 @@ class _PushButtonState extends State<PushButton>
         theme.typography.headline.copyWith(color: foregroundColor);
 
     return MouseRegion(
-      cursor: SystemMouseCursors.click,
+      cursor: theme.mouseCursor,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTapDown: enabled ? _handleTapDown : null,

--- a/lib/src/buttons/radio_button.dart
+++ b/lib/src/buttons/radio_button.dart
@@ -82,53 +82,56 @@ class MacosRadioButton extends StatelessWidget {
     assert(debugCheckHasMacosTheme(context));
     final MacosThemeData theme = MacosTheme.of(context);
     final isLight = !theme.brightness.isDark;
-    return GestureDetector(
-      onTap: () => onChanged?.call(!value),
-      child: Semantics(
-        checked: value,
-        label: semanticLabel,
-        child: Container(
-          height: size,
-          width: size,
-          decoration: BoxDecoration(
-            border: Border.all(
-              style: isDisabled ? BorderStyle.none : BorderStyle.solid,
-              width: value ? size / 4.0 : 1,
-              color: MacosDynamicColor.resolve(
-                value ? onColor ?? theme.primaryColor : offColor,
-                context,
-              ),
-            ),
-            shape: BoxShape.circle,
-          ),
-          // The inner color is inside another container because it sometimes
-          // overlap the border when used together
+    return MouseRegion(
+      cursor: theme.mouseCursor,
+      child: GestureDetector(
+        onTap: () => onChanged?.call(!value),
+        child: Semantics(
+          checked: value,
+          label: semanticLabel,
           child: Container(
+            height: size,
+            width: size,
             decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: MacosDynamicColor.resolve(
-                innerColor ??
-                    (isDisabled
-                        ? CupertinoColors.quaternarySystemFill
-                        : value || isLight
-                            ? CupertinoColors.white
-                            : CupertinoColors.tertiarySystemFill),
-                context,
+              border: Border.all(
+                style: isDisabled ? BorderStyle.none : BorderStyle.solid,
+                width: value ? size / 4.0 : 1,
+                color: MacosDynamicColor.resolve(
+                  value ? onColor ?? theme.primaryColor : offColor,
+                  context,
+                ),
               ),
-              boxShadow: [
-                BoxShadow(
-                  color: Color.fromRGBO(0, 0, 0, 0.05),
-                  offset: Offset(-0.05, -0.05),
+              shape: BoxShape.circle,
+            ),
+            // The inner color is inside another container because it sometimes
+            // overlap the border when used together
+            child: Container(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: MacosDynamicColor.resolve(
+                  innerColor ??
+                      (isDisabled
+                          ? CupertinoColors.quaternarySystemFill
+                          : value || isLight
+                              ? CupertinoColors.white
+                              : CupertinoColors.tertiarySystemFill),
+                  context,
                 ),
-                BoxShadow(
-                  color: Color.fromRGBO(0, 0, 0, 0.05),
-                  offset: Offset(0.05, 0.05),
-                ),
-                BoxShadow(
-                  color: CupertinoColors.tertiarySystemFill,
-                  offset: Offset(0, 0),
-                ),
-              ],
+                boxShadow: [
+                  BoxShadow(
+                    color: Color.fromRGBO(0, 0, 0, 0.05),
+                    offset: Offset(-0.05, -0.05),
+                  ),
+                  BoxShadow(
+                    color: Color.fromRGBO(0, 0, 0, 0.05),
+                    offset: Offset(0.05, 0.05),
+                  ),
+                  BoxShadow(
+                    color: CupertinoColors.tertiarySystemFill,
+                    offset: Offset(0, 0),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
 
@@ -195,6 +196,7 @@ class MacosThemeData with Diagnosticable {
     TooltipThemeData? tooltipTheme,
     VisualDensity? visualDensity,
     ScrollbarThemeData? scrollbarTheme,
+    MouseCursor? mouseCursor,
   }) {
     final Brightness _brightness = brightness ?? Brightness.light;
     final bool isDark = _brightness == Brightness.dark;
@@ -232,6 +234,16 @@ class MacosThemeData with Diagnosticable {
 
     visualDensity ??= VisualDensity.adaptivePlatformDensity;
 
+    mouseCursor ??= () {
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.macOS:
+        case TargetPlatform.iOS:
+          return MouseCursor.defer;
+        default:
+          return SystemMouseCursors.click;
+      }
+    }();
+
     return MacosThemeData.raw(
       brightness: _brightness,
       primaryColor: primaryColor,
@@ -243,6 +255,7 @@ class MacosThemeData with Diagnosticable {
       tooltipTheme: tooltipTheme,
       visualDensity: visualDensity,
       scrollbarTheme: scrollbarTheme,
+      mouseCursor: mouseCursor,
     );
   }
 
@@ -263,6 +276,7 @@ class MacosThemeData with Diagnosticable {
     required this.tooltipTheme,
     required this.visualDensity,
     required this.scrollbarTheme,
+    required this.mouseCursor,
   });
 
   /// A default light theme.
@@ -321,10 +335,19 @@ class MacosThemeData with Diagnosticable {
   /// The default style for [MacosScrollbar]s below the overall [MacosTheme]
   final ScrollbarThemeData scrollbarTheme;
 
+  /// The mouse cursor used on the macos inputs.
+  ///
+  /// {@template macos_ui.theme.mouseCursor}
+  /// When the current platform is macOS or iOS, [MouseCursor.defer] is used.
+  /// On the other platforms, [SystemMouseCursors.click] is used.
+  /// {@endTemplate}
+  final MouseCursor mouseCursor;
+
   /// Linearly interpolate between two themes.
   static MacosThemeData lerp(MacosThemeData a, MacosThemeData b, double t) {
     return MacosThemeData.raw(
       brightness: t < 0.5 ? a.brightness : b.brightness,
+      mouseCursor: t < 0.5 ? a.mouseCursor : b.mouseCursor,
       dividerColor: Color.lerp(a.dividerColor, b.dividerColor, t)!,
       primaryColor: Color.lerp(a.primaryColor, b.primaryColor, t)!,
       canvasColor: Color.lerp(a.primaryColor, b.primaryColor, t)!,
@@ -352,6 +375,7 @@ class MacosThemeData with Diagnosticable {
     TooltipThemeData? tooltipTheme,
     VisualDensity? visualDensity,
     ScrollbarThemeData? scrollbarTheme,
+    MouseCursor? mouseCursor,
   }) {
     return MacosThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -364,6 +388,7 @@ class MacosThemeData with Diagnosticable {
       tooltipTheme: this.tooltipTheme.copyWith(tooltipTheme),
       visualDensity: visualDensity ?? this.visualDensity,
       scrollbarTheme: scrollbarTheme ?? this.scrollbarTheme,
+      mouseCursor: mouseCursor ?? this.mouseCursor,
     );
   }
 
@@ -376,6 +401,8 @@ class MacosThemeData with Diagnosticable {
     properties.add(ColorProperty('dividerColor', dividerColor));
     properties
         .add(DiagnosticsProperty<MacosTypography>('typography', typography));
+    properties
+        .add(DiagnosticsProperty<MouseCursor>('mouseCursor', mouseCursor));
     properties.add(DiagnosticsProperty<PushButtonThemeData>(
       'pushButtonTheme',
       pushButtonTheme,


### PR DESCRIPTION
<!--

    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioninig issues related to this pull request

-->

Add `mouseCursor` to `MacosThemeData`. By default, on Apple platforms, `MouseCursor.defer` (no cursor) is used. On the other platforms, `SystemMouseCursors.click` is used.

Closes #139 

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [ ] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->