### PR TITLE
Additional options for Alert and Sidebar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.6.1]
+* Removes blank area above sidebar contents, this can be set by developer using padding or container in builder
+* Adds optional top attribute, like the bottom attribute, to Sidebar.
+* Makes text alignment avaialble for title and message in MacosAlertDialog
+* Makes icon optional for MacosAlertDialog
+
 ## [0.6.0]
 * Improved `MacosAlertDialog` design
 * Added `showMacosAlertDialog` to display a `MacosAlertDialog` with standard macOS animations and behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.6.1]
 * Removes blank area above sidebar contents, this can be set by developer using padding or container in builder
 * Adds optional top attribute, like the bottom attribute, to Sidebar.
-* Makes text alignment avaialble for title and message in MacosAlertDialog
+* Makes text alignment available for title and message in MacosAlertDialog
 * Makes icon optional for MacosAlertDialog
 * Fix `builder` property in `MacosApp` never being used ([#148](https://github.com/GroovinChip/macos_ui/issues/148))
 

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -46,11 +46,10 @@ class MacosAlertDialog extends StatelessWidget {
     this.secondaryButton,
     this.horizontalActions = true,
     this.suppress,
-  }) : 
-    _appIcon = appIcon, 
-    _titleAlign = titleAlign ?? TextAlign.center,
-    _messageAlign = titleAlign ?? TextAlign.center,
-    super(key: key);
+  })  : _appIcon = appIcon,
+        _titleAlign = titleAlign ?? TextAlign.center,
+        _messageAlign = titleAlign ?? TextAlign.center,
+        super(key: key);
 
   /// This should be your application's icon.
   ///
@@ -63,7 +62,7 @@ class MacosAlertDialog extends StatelessWidget {
   final Widget title;
 
   /// How to align title
-  /// 
+  ///
   /// Defaults to center
   TextAlign _titleAlign;
 
@@ -73,7 +72,7 @@ class MacosAlertDialog extends StatelessWidget {
   final Widget message;
 
   /// How to align message
-  /// 
+  ///
   /// Defaults to center
   TextAlign _messageAlign;
 
@@ -179,13 +178,13 @@ class MacosAlertDialog extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 28),
-              if(_appIcon != null) ...[
-                  ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxHeight: 56,
-                      maxWidth: 56,
-                    ),
-                    child: _appIcon!,
+              if (_appIcon != null) ...[
+                ConstrainedBox(
+                  constraints: BoxConstraints(
+                    maxHeight: 56,
+                    maxWidth: 56,
+                  ),
+                  child: _appIcon!,
                 ),
                 const SizedBox(height: 28),
               ],

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -35,31 +35,47 @@ const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 /// ```
 class MacosAlertDialog extends StatelessWidget {
   /// Builds a macOS-style Alert Dialog
-  const MacosAlertDialog({
+  MacosAlertDialog({
     Key? key,
-    required this.appIcon,
+    Widget? appIcon,
+    TextAlign? titleAlign,
+    TextAlign? messageAlign,
     required this.title,
     required this.message,
     required this.primaryButton,
     this.secondaryButton,
     this.horizontalActions = true,
     this.suppress,
-  }) : super(key: key);
+  }) : 
+    _appIcon = appIcon, 
+    _titleAlign = titleAlign ?? TextAlign.center,
+    _messageAlign = titleAlign ?? TextAlign.center,
+    super(key: key);
 
   /// This should be your application's icon.
   ///
   /// The size of this widget should be 56x56.
-  final Widget appIcon;
+  Widget? _appIcon;
 
   /// The title for the dialog.
   ///
   /// Typically a Text widget.
   final Widget title;
 
+  /// How to align title
+  /// 
+  /// Defaults to center
+  TextAlign _titleAlign;
+
   /// The content to display in the dialog.
   ///
   /// Typically a Text widget.
   final Widget message;
+
+  /// How to align message
+  /// 
+  /// Defaults to center
+  TextAlign _messageAlign;
 
   /// The primary action a user can take.
   ///
@@ -160,24 +176,27 @@ class MacosAlertDialog extends StatelessWidget {
           ),
           child: Column(
             mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               const SizedBox(height: 28),
-              ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxHeight: 56,
-                  maxWidth: 56,
+              if(_appIcon != null) ...[
+                  ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxHeight: 56,
+                      maxWidth: 56,
+                    ),
+                    child: _appIcon!,
                 ),
-                child: appIcon,
-              ),
-              const SizedBox(height: 28),
+                const SizedBox(height: 28),
+              ],
               DefaultTextStyle(
                 style: MacosTheme.of(context).typography.headline,
-                textAlign: TextAlign.center,
+                textAlign: _titleAlign,
                 child: title,
               ),
               const SizedBox(height: 16),
               DefaultTextStyle(
-                textAlign: TextAlign.center,
+                textAlign: _messageAlign,
                 style: MacosTheme.of(context).typography.headline,
                 child: message,
               ),

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -166,7 +166,6 @@ class _MacosScaffoldState extends State<MacosScaffold> {
                   color: sidebarBackgroundColor,
                   child: Column(
                     children: [
-                      SizedBox(height: titleBarHeight - 1),
                       if (_sidebarScrollController.hasClients &&
                           _sidebarScrollController.offset > 0.0)
                         Divider(thickness: 1, height: 1, color: dividerColor),

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -166,9 +166,7 @@ class _MacosScaffoldState extends State<MacosScaffold> {
                   color: sidebarBackgroundColor,
                   child: Column(
                     children: [
-                      if (widget.sidebar?.top != null)
-                      widget.sidebar!.top!,
-
+                      if (widget.sidebar?.top != null) widget.sidebar!.top!,
                       if (_sidebarScrollController.hasClients &&
                           _sidebarScrollController.offset > 0.0)
                         Divider(thickness: 1, height: 1, color: dividerColor),

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -166,6 +166,9 @@ class _MacosScaffoldState extends State<MacosScaffold> {
                   color: sidebarBackgroundColor,
                   child: Column(
                     children: [
+                      if (widget.sidebar?.top != null)
+                      widget.sidebar!.top!,
+
                       if (_sidebarScrollController.hasClients &&
                           _sidebarScrollController.offset > 0.0)
                         Divider(thickness: 1, height: 1, color: dividerColor),

--- a/lib/src/layout/sidebar.dart
+++ b/lib/src/layout/sidebar.dart
@@ -16,6 +16,7 @@ class Sidebar {
     this.startWidth,
     this.padding = EdgeInsets.zero,
     this.scaffoldBreakpoint = 556.0,
+    this.top,
     this.bottom,
   });
 
@@ -74,6 +75,9 @@ class Sidebar {
 
   /// Specifies the width of the scaffold at which this [ResizablePane] will be hidden.
   final double scaffoldBreakpoint;
+
+  /// Widget that should be displayed at the Top of the Sidebar
+  final Widget? top;
 
   /// Widget that should be displayed at the Bottom of the Sidebar
   final Widget? bottom;


### PR DESCRIPTION
This PR adds ability to add a top widget to a Sidebar, or nothing. This will also remove the titlebar sized gap at the top of the Sidebar's content. If a dev wants that padding that can add it as a sized box on Sidebar's `top` attribute. It also adds ability to set the text alignment on an Alert's title and message.

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [X] I have added/updated relevant documentation (header doc) <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->