### PR TITLE
0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.7.3]
+* Fixed bug where cursor would not change caret location on mouse click
+
 ## [0.7.2]
 * Upgraded various `copyWith` functions
 * Added `==` and `hashCode` to various classes

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.2"
+    version: "0.7.3"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -116,7 +116,9 @@ class _TextFieldSelectionGestureDetectorBuilder
         return;
       }
     }
-    super.onSingleTapUp(details);
+    if (delegate.selectionEnabled) {
+      renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+    }
     _state._requestKeyboard();
     if (_state.widget.onTap != null) _state.widget.onTap!();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.7.2
+version: 0.7.3
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
This PR fixes a bug where the mouse cursor click would not change textfield caret location

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->