### PR TITLE
`MacosListTile` updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.8.2]
+* Updates to `MacosListTile`:
+  * Added `leadingWhitespace` property
+  * Added `onClick` callback
+  * Added `onLongPress` callback
+  * Added `mouseCursor` property
+
 ## [0.8.1]
 * Fix the outer border of `MacosSheet` not having a border radius
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
           title: 'macos_ui example',
           theme: MacosThemeData.light(),
           darkTheme: MacosThemeData.dark(),
-          themeMode: ThemeMode.light,
+          themeMode: appTheme.mode,
           debugShowCheckedModeBanner: false,
           home: const Demo(),
         );
@@ -82,7 +82,7 @@ class _DemoState extends State<Demo> {
           child: MacosListTile(
             leading: Icon(CupertinoIcons.profile_circled),
             title: Text('Tim Apple'),
-            //subtitle: Text('tim@apple.com'),
+            subtitle: Text('tim@apple.com'),
           ),
         ),
         builder: (context, controller) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,7 +27,7 @@ class MyApp extends StatelessWidget {
           title: 'macos_ui example',
           theme: MacosThemeData.light(),
           darkTheme: MacosThemeData.dark(),
-          themeMode: appTheme.mode,
+          themeMode: ThemeMode.light,
           debugShowCheckedModeBanner: false,
           home: const Demo(),
         );
@@ -77,15 +77,12 @@ class _DemoState extends State<Demo> {
       ),
       sidebar: Sidebar(
         minWidth: 200,
-        bottom: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              const Icon(CupertinoIcons.profile_circled),
-              const SizedBox(width: 8.0),
-              const Text('Tim Apple'),
-            ],
+        bottom: const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: MacosListTile(
+            leading: Icon(CupertinoIcons.profile_circled),
+            title: Text('Tim Apple'),
+            //subtitle: Text('tim@apple.com'),
           ),
         ),
         builder: (context, controller) {

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -248,18 +248,14 @@ class MacosuiSheet extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                MacosListTile(
-                  leading: const Icon(CupertinoIcons.lightbulb),
+                const MacosListTile(
+                  leading: Icon(CupertinoIcons.lightbulb),
                   title: Text(
                     'A robust library of Flutter components for macOS',
-                    style: MacosTheme.of(context).typography.headline,
+                    //style: MacosTheme.of(context).typography.headline,
                   ),
                   subtitle: Text(
                     'Create native looking macOS applications using Flutter',
-                    style:
-                        MacosTheme.of(context).typography.subheadline.copyWith(
-                              color: MacosColors.systemGrayColor,
-                            ),
                   ),
                 ),
               ],

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -260,10 +260,24 @@ class MacosuiSheet extends StatelessWidget {
                 ),
               ],
             ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const MacosListTile(
+                  leading: Icon(CupertinoIcons.bolt),
+                  title: Text(
+                    'Create beautiful macOS applications in minutes',
+                    //style: MacosTheme.of(context).typography.headline,
+                  ),
+                ),
+                const SizedBox(width: 10),
+              ],
+            ),
             const Spacer(),
             PushButton(
               buttonSize: ButtonSize.large,
-              child: const Text('Dismiss'),
+              child: const Text('Get started'),
               onPressed: () => Navigator.of(context).pop(),
             ),
             const SizedBox(height: 50),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.8.2"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -11,6 +11,8 @@ class MacosListTile extends StatelessWidget {
     required this.title,
     this.subtitle,
     this.leadingWhitespace = 8,
+    this.onClick,
+    this.onLongPress,
   }) : super(key: key);
 
   /// A widget to display before the [title].
@@ -27,34 +29,44 @@ class MacosListTile extends StatelessWidget {
   /// Defaults to `8`.
   final double? leadingWhitespace;
 
+  /// A callback to perform when the widget is clicked.
+  final VoidCallback? onClick;
+
+  /// A callback to perform when the widget is long-pressed.
+  final VoidCallback? onLongPress;
+
   @override
   Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (leading != null) leading!,
-        SizedBox(width: leadingWhitespace),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            DefaultTextStyle(
-              style: MacosTheme.of(context).typography.headline.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-              child: title,
-            ),
-            if (subtitle != null)
+    return GestureDetector(
+      onTap: onClick,
+      onLongPress: onLongPress,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (leading != null) leading!,
+          SizedBox(width: leadingWhitespace),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
               DefaultTextStyle(
-                style: MacosTheme.of(context).typography.subheadline.copyWith(
-                      color: MacosTheme.brightnessOf(context).isDark
-                          ? MacosColors.systemGrayColor
-                          : const MacosColor(0xff88888C),
+                style: MacosTheme.of(context).typography.headline.copyWith(
+                      fontWeight: FontWeight.bold,
                     ),
-                child: subtitle!,
+                child: title,
               ),
-          ],
-        ),
-      ],
+              if (subtitle != null)
+                DefaultTextStyle(
+                  style: MacosTheme.of(context).typography.subheadline.copyWith(
+                        color: MacosTheme.brightnessOf(context).isDark
+                            ? MacosColors.systemGrayColor
+                            : const MacosColor(0xff88888C),
+                      ),
+                  child: subtitle!,
+                ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -41,11 +41,11 @@ class MacosListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: mouseCursor,
-      child: GestureDetector(
-        onTap: onClick,
-        onLongPress: onLongPress,
+    return GestureDetector(
+      onTap: onClick,
+      onLongPress: onLongPress,
+      child: MouseRegion(
+        cursor: mouseCursor,
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -1,3 +1,4 @@
+import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
 
 /// A widget that aims to approximate the [ListTile] widget found in
@@ -9,6 +10,7 @@ class MacosListTile extends StatelessWidget {
     this.leading,
     required this.title,
     this.subtitle,
+    this.leadingWhitespace = 8,
   }) : super(key: key);
 
   /// A widget to display before the [title].
@@ -20,18 +22,36 @@ class MacosListTile extends StatelessWidget {
   /// Additional content displayed below the [title].
   final Widget? subtitle;
 
+  /// The amount of whitespace between the [leading] and [title] widgets.
+  ///
+  /// Defaults to `8`.
+  final double? leadingWhitespace;
+
   @override
   Widget build(BuildContext context) {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (leading != null) leading!,
-        const SizedBox(width: 8),
+        SizedBox(width: leadingWhitespace),
         Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            title,
-            if (subtitle != null) subtitle!,
+            DefaultTextStyle(
+              style: MacosTheme.of(context).typography.headline.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+              child: title,
+            ),
+            if (subtitle != null)
+              DefaultTextStyle(
+                style: MacosTheme.of(context).typography.subheadline.copyWith(
+                      color: MacosTheme.brightnessOf(context).isDark
+                          ? MacosColors.systemGrayColor
+                          : const MacosColor(0xff88888C),
+                    ),
+                child: subtitle!,
+              ),
           ],
         ),
       ],

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -13,6 +13,7 @@ class MacosListTile extends StatelessWidget {
     this.leadingWhitespace = 8,
     this.onClick,
     this.onLongPress,
+    this.mouseCursor = MouseCursor.defer,
   }) : super(key: key);
 
   /// A widget to display before the [title].
@@ -35,37 +36,44 @@ class MacosListTile extends StatelessWidget {
   /// A callback to perform when the widget is long-pressed.
   final VoidCallback? onLongPress;
 
+  /// The [MouseCursor] to use for this widget.
+  final MouseCursor mouseCursor;
+
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onClick,
-      onLongPress: onLongPress,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (leading != null) leading!,
-          SizedBox(width: leadingWhitespace),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              DefaultTextStyle(
-                style: MacosTheme.of(context).typography.headline.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                child: title,
-              ),
-              if (subtitle != null)
+    return MouseRegion(
+      cursor: mouseCursor,
+
+      child: GestureDetector(
+        onTap: onClick,
+        onLongPress: onLongPress,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (leading != null) leading!,
+            SizedBox(width: leadingWhitespace),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
                 DefaultTextStyle(
-                  style: MacosTheme.of(context).typography.subheadline.copyWith(
-                        color: MacosTheme.brightnessOf(context).isDark
-                            ? MacosColors.systemGrayColor
-                            : const MacosColor(0xff88888C),
+                  style: MacosTheme.of(context).typography.headline.copyWith(
+                        fontWeight: FontWeight.bold,
                       ),
-                  child: subtitle!,
+                  child: title,
                 ),
-            ],
-          ),
-        ],
+                if (subtitle != null)
+                  DefaultTextStyle(
+                    style: MacosTheme.of(context).typography.subheadline.copyWith(
+                          color: MacosTheme.brightnessOf(context).isDark
+                              ? MacosColors.systemGrayColor
+                              : const MacosColor(0xff88888C),
+                        ),
+                    child: subtitle!,
+                  ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -43,7 +43,6 @@ class MacosListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return MouseRegion(
       cursor: mouseCursor,
-
       child: GestureDetector(
         onTap: onClick,
         onLongPress: onLongPress,

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -62,11 +62,12 @@ class MacosListTile extends StatelessWidget {
                 ),
                 if (subtitle != null)
                   DefaultTextStyle(
-                    style: MacosTheme.of(context).typography.subheadline.copyWith(
-                          color: MacosTheme.brightnessOf(context).isDark
-                              ? MacosColors.systemGrayColor
-                              : const MacosColor(0xff88888C),
-                        ),
+                    style:
+                        MacosTheme.of(context).typography.subheadline.copyWith(
+                              color: MacosTheme.brightnessOf(context).isDark
+                                  ? MacosColors.systemGrayColor
+                                  : const MacosColor(0xff88888C),
+                            ),
                     child: subtitle!,
                   ),
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.8.1
+version: 0.8.2
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/test/layout/macos_list_tile_test.dart
+++ b/test/layout/macos_list_tile_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';

--- a/test/layout/macos_list_tile_test.dart
+++ b/test/layout/macos_list_tile_test.dart
@@ -55,6 +55,7 @@ void main() {
                 builder: (context, scrollController) {
                   return MacosListTile(
                     title: const Text('List Tile'),
+                    subtitle: const Text('Subtitle'),
                     onClick: mockOnLongPressedFunction.handler,
                   );
                 },

--- a/test/layout/macos_list_tile_test.dart
+++ b/test/layout/macos_list_tile_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/library.dart';
+
+import '../mocks.dart';
+
+void main() {
+  late MockOnPressedFunction mockOnPressedFunction;
+  late MockOnLongPressedFunction mockOnLongPressedFunction;
+
+  setUp(() {
+    mockOnPressedFunction = MockOnPressedFunction();
+    mockOnLongPressedFunction = MockOnLongPressedFunction();
+  });
+
+  testWidgets('MacosListTile onClick works', (tester) async {
+    await tester.pumpWidget(
+      MacosApp(
+        theme: MacosThemeData.dark().copyWith(
+          pushButtonTheme: const PushButtonThemeData(),
+        ),
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, scrollController) {
+                  return MacosListTile(
+                    title: const Text('List Tile'),
+                    onClick: mockOnPressedFunction.handler,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final listTile = find.byType(MacosListTile);
+    expect(listTile, findsOneWidget);
+    await tester.tap(listTile);
+    expect(mockOnPressedFunction.called, 2);
+  });
+
+  testWidgets('MacosListTile onLongPress works', (tester) async {
+    await tester.pumpWidget(
+      MacosApp(
+        theme: MacosThemeData.dark().copyWith(
+          pushButtonTheme: const PushButtonThemeData(),
+        ),
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, scrollController) {
+                  return MacosListTile(
+                    title: const Text('List Tile'),
+                    onClick: mockOnLongPressedFunction.handler,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final listTile = find.byType(MacosListTile);
+    await tester.longPress(listTile);
+    await tester.pumpAndSettle();
+
+    expect(mockOnLongPressedFunction.called, 3);
+  });
+}

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -13,3 +13,11 @@ class MockOnPressedFunction {
     called = 2;
   }
 }
+
+class MockOnLongPressedFunction {
+  int called = 0;
+
+  void handler() {
+    called = 3;
+  }
+}


### PR DESCRIPTION
This PR adds a number of new properties to `MacosListTile` to make it more customizable:

* Added `leadingWhitespace` property
* Added `onClick` callback
* Added `onLongPress` callback
* Added `mouseCursor` property


## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->