### PR TITLE
0.9.1 Icon button updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.9.1]
+* Added top-level theming for `MacosIconButton`
+  * Introduces the `MacosIconButtonTheme` InheritedTheme and the `MacosIconButtonThemeData` theme class
+* Updates `MacosThemeData` and `MacosIconButton` to use the new `MacosIconButtonThemeData`
+* Removes an unnecessary setting of VisualDensity from `MacosThemeData.dark()`
+
 ## [0.9.0]
 * Added [native_context_menu](https://pub.dev/packages/native_context_menu) as a dependency for native context menus!
 

--- a/example/lib/pages/buttons.dart
+++ b/example/lib/pages/buttons.dart
@@ -61,7 +61,6 @@ class _ButtonsPageState extends State<ButtonsPage> {
                     const SizedBox(width: 16.0),
                     MacosBackButton(
                       onPressed: () => print('click'),
-                      //fillColor: Colors.transparent,
                     ),
                   ],
                 ),
@@ -81,18 +80,18 @@ class _ButtonsPageState extends State<ButtonsPage> {
                       onPressed: () {},
                     ),
                     const SizedBox(width: 8),
-                    MacosIconButton(
-                      icon: const Icon(
-                        CupertinoIcons.star_fill,
+                    const MacosIconButton(
+                      icon: Icon(
+                        CupertinoIcons.plus_app,
                         color: Colors.white,
                       ),
                       shape: BoxShape.circle,
-                      onPressed: () {},
+                      //onPressed: () {},
                     ),
                     const SizedBox(width: 8),
                     MacosIconButton(
                       icon: const Icon(
-                        CupertinoIcons.star_fill,
+                        CupertinoIcons.minus_square,
                         color: Colors.white,
                       ),
                       backgroundColor: Colors.transparent,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -94,7 +94,7 @@ packages:
       name: native_context_menu
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+1"
+    version: "0.1.2+2"
   nested:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.9.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -184,10 +184,10 @@ class MacosIconButtonState extends State<MacosIconButton>
   @override
   Widget build(BuildContext context) {
     final bool enabled = widget.enabled;
-    final MacosThemeData theme = MacosTheme.of(context);
+    final theme = MacosIconButtonTheme.of(context);
 
     final Color backgroundColor =
-        widget.backgroundColor ?? CupertinoColors.systemBlue;
+        widget.backgroundColor ?? theme.backgroundColor!;
 
     final Color? disabledColor;
 
@@ -197,9 +197,7 @@ class MacosIconButtonState extends State<MacosIconButton>
         context,
       );
     } else {
-      disabledColor = theme.brightness.isDark
-          ? const Color(0xff353535)
-          : const Color(0xffE5E5E5);
+      disabledColor = theme.disabledColor;
     }
 
     return MouseRegion(

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -343,6 +343,7 @@ class MacosIconButtonThemeData with Diagnosticable {
     properties
         .add(DiagnosticsProperty<BorderRadius?>('borderRadius', borderRadius));
     properties.add(
-        DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints));
+      DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints),
+    );
   }
 }

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -244,3 +244,103 @@ class MacosIconButtonState extends State<MacosIconButton>
     );
   }
 }
+
+class MacosIconButtonTheme extends InheritedTheme {
+  const MacosIconButtonTheme({
+    Key? key,
+    required this.data,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  final MacosIconButtonThemeData data;
+
+  static MacosIconButtonThemeData of(BuildContext context) {
+    final MacosIconButtonTheme? buttonTheme =
+        context.dependOnInheritedWidgetOfExactType<MacosIconButtonTheme>();
+    return buttonTheme?.data ?? MacosTheme.of(context).macosIconButtonTheme;
+  }
+
+  Widget wrap(BuildContext context, Widget child) {
+    return MacosIconButtonTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(MacosIconButtonTheme oldWidget) =>
+      data != oldWidget.data;
+}
+
+class MacosIconButtonThemeData with Diagnosticable {
+  const MacosIconButtonThemeData({
+    this.backgroundColor,
+    this.disabledColor,
+    this.shape,
+    this.borderRadius,
+    this.boxConstraints,
+  });
+
+  final Color? backgroundColor;
+  final Color? disabledColor;
+  final BoxShape? shape;
+  final BorderRadius? borderRadius;
+  final BoxConstraints? boxConstraints;
+
+  MacosIconButtonThemeData copyWith({
+    Color? backgroundColor,
+    Color? disabledColor,
+    BoxShape? shape,
+    BorderRadius? borderRadius,
+    BoxConstraints? boxConstraints,
+  }) {
+    return MacosIconButtonThemeData(
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      disabledColor: disabledColor ?? this.disabledColor,
+      shape: shape ?? this.shape,
+      borderRadius: borderRadius ?? this.borderRadius,
+      boxConstraints: boxConstraints ?? this.boxConstraints,
+    );
+  }
+
+  static MacosIconButtonThemeData lerp(
+    MacosIconButtonThemeData a,
+    MacosIconButtonThemeData b,
+    double t,
+  ) {
+    return MacosIconButtonThemeData(
+      backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
+      disabledColor: Color.lerp(a.disabledColor, b.disabledColor, t),
+      shape: b.shape,
+      borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
+      boxConstraints:
+          BoxConstraints.lerp(a.boxConstraints, b.boxConstraints, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MacosIconButtonThemeData &&
+          runtimeType == other.runtimeType &&
+          backgroundColor == other.backgroundColor &&
+          disabledColor == other.disabledColor &&
+          shape == other.shape &&
+          borderRadius == other.borderRadius &&
+          boxConstraints == other.boxConstraints;
+
+  @override
+  int get hashCode =>
+      backgroundColor.hashCode ^
+      disabledColor.hashCode ^
+      shape.hashCode ^
+      borderRadius.hashCode ^
+      boxConstraints.hashCode;
+  
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('backgroundColor', backgroundColor));
+    properties.add(ColorProperty('disabledColor', disabledColor));
+    properties.add(EnumProperty<BoxShape?>('shape', shape));
+    properties.add(DiagnosticsProperty<BorderRadius?>('borderRadius', borderRadius));
+    properties.add(DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints));
+  }
+}

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -245,15 +245,34 @@ class MacosIconButtonState extends State<MacosIconButton>
   }
 }
 
+/// Overrides the default style of its [MacosIconButton] descendants.
+///
+/// See also:
+///
+///  * [MacosIconButtonThemeData], which is used to configure this theme.
 class MacosIconButtonTheme extends InheritedTheme {
+  /// Builds a [MacosIconButtonTheme].
+  ///
+  /// The [data] parameter must not be null.
   const MacosIconButtonTheme({
     Key? key,
     required this.data,
     required Widget child,
   }) : super(key: key, child: child);
 
+  /// The configuration of this theme.
   final MacosIconButtonThemeData data;
 
+  /// The closest instance of this class that encloses the given context.
+  ///
+  /// If there is no enclosing [MacosIconButtonTheme] widget, then
+  /// [MacosThemeData.macosIconButtonTheme] is used.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// final theme = MacosIconButtonTheme.of(context);
+  /// ```
   static MacosIconButtonThemeData of(BuildContext context) {
     final MacosIconButtonTheme? buttonTheme =
         context.dependOnInheritedWidgetOfExactType<MacosIconButtonTheme>();
@@ -269,7 +288,17 @@ class MacosIconButtonTheme extends InheritedTheme {
       data != oldWidget.data;
 }
 
+/// A style that overrides the default appearance of
+/// [MacosIconButton]s when it's used with [MacosIconButtonTheme] or with the
+/// overall [MacosTheme]'s [MacosThemeData.macosIconButtonTheme].
+///
+/// See also:
+///
+///  * [MacosIconButtonTheme], the theme which is configured with this class.
+///  * [MacosThemeData.macosIconButtonTheme], which can be used to override
+///  the default style for [MacosIconButton]s below the overall [MacosTheme].
 class MacosIconButtonThemeData with Diagnosticable {
+  /// Builds a [MacosIconButtonThemeData].
   const MacosIconButtonThemeData({
     this.backgroundColor,
     this.disabledColor,
@@ -278,12 +307,22 @@ class MacosIconButtonThemeData with Diagnosticable {
     this.boxConstraints,
   });
 
+  /// The default background color for [MacosIconButton].
   final Color? backgroundColor;
+
+  /// The default disabled color for [MacosIconButton].
   final Color? disabledColor;
+
+  /// The default shape for [MacosIconButton].
   final BoxShape? shape;
+
+  /// The default border radius for [MacosIconButton].
   final BorderRadius? borderRadius;
+
+  /// The default box constraints for [MacosIconButton].
   final BoxConstraints? boxConstraints;
 
+  /// Copies this [MacosIconButtonThemeData] into another.
   MacosIconButtonThemeData copyWith({
     Color? backgroundColor,
     Color? disabledColor,
@@ -300,6 +339,9 @@ class MacosIconButtonThemeData with Diagnosticable {
     );
   }
 
+  /// Linearly interpolate between two [MacosIconButtonThemeData].
+  ///
+  /// All the properties must be non-null.
   static MacosIconButtonThemeData lerp(
     MacosIconButtonThemeData a,
     MacosIconButtonThemeData b,

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -320,8 +320,8 @@ class MacosIconButtonThemeData with Diagnosticable {
       identical(this, other) ||
       other is MacosIconButtonThemeData &&
           runtimeType == other.runtimeType &&
-          backgroundColor == other.backgroundColor &&
-          disabledColor == other.disabledColor &&
+          backgroundColor?.value == other.backgroundColor?.value &&
+          disabledColor?.value == other.disabledColor?.value &&
           shape == other.shape &&
           borderRadius == other.borderRadius &&
           boxConstraints == other.boxConstraints;
@@ -333,14 +333,16 @@ class MacosIconButtonThemeData with Diagnosticable {
       shape.hashCode ^
       borderRadius.hashCode ^
       boxConstraints.hashCode;
-  
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(ColorProperty('backgroundColor', backgroundColor));
     properties.add(ColorProperty('disabledColor', disabledColor));
     properties.add(EnumProperty<BoxShape?>('shape', shape));
-    properties.add(DiagnosticsProperty<BorderRadius?>('borderRadius', borderRadius));
-    properties.add(DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints));
+    properties
+        .add(DiagnosticsProperty<BorderRadius?>('borderRadius', borderRadius));
+    properties.add(
+        DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints));
   }
 }

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -230,7 +230,18 @@ class MacosThemeData with Diagnosticable {
       textStyle: typography.callout,
     );
     scrollbarTheme ??= const ScrollbarThemeData();
-    macosIconButtonThemeData ??= const MacosIconButtonThemeData();
+    macosIconButtonThemeData ??= const MacosIconButtonThemeData(
+      backgroundColor: MacosColors.transparent,
+      disabledColor:
+          MacosColors.systemGrayColor, // TODO: correct disabled color
+      shape: BoxShape.circle,
+      boxConstraints: BoxConstraints(
+        minHeight: 20,
+        minWidth: 20,
+        maxWidth: 30,
+        maxHeight: 30,
+      ),
+    );
 
     visualDensity ??= VisualDensity.adaptivePlatformDensity;
 

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -195,6 +195,7 @@ class MacosThemeData with Diagnosticable {
     TooltipThemeData? tooltipTheme,
     VisualDensity? visualDensity,
     ScrollbarThemeData? scrollbarTheme,
+    MacosIconButtonThemeData? macosIconButtonThemeData,
   }) {
     final Brightness _brightness = brightness ?? Brightness.light;
     final bool isDark = _brightness == Brightness.dark;
@@ -229,6 +230,7 @@ class MacosThemeData with Diagnosticable {
       textStyle: typography.callout,
     );
     scrollbarTheme ??= const ScrollbarThemeData();
+    macosIconButtonThemeData ??= const MacosIconButtonThemeData();
 
     visualDensity ??= VisualDensity.adaptivePlatformDensity;
 
@@ -243,6 +245,7 @@ class MacosThemeData with Diagnosticable {
       tooltipTheme: tooltipTheme,
       visualDensity: visualDensity,
       scrollbarTheme: scrollbarTheme,
+      macosIconButtonTheme: macosIconButtonThemeData,
     );
   }
 
@@ -263,6 +266,7 @@ class MacosThemeData with Diagnosticable {
     required this.tooltipTheme,
     required this.visualDensity,
     required this.scrollbarTheme,
+    required this.macosIconButtonTheme,
   });
 
   /// A default light theme.
@@ -321,6 +325,8 @@ class MacosThemeData with Diagnosticable {
   /// The default style for [MacosScrollbar]s below the overall [MacosTheme]
   final ScrollbarThemeData scrollbarTheme;
 
+  final MacosIconButtonThemeData macosIconButtonTheme;
+
   /// Linearly interpolate between two themes.
   static MacosThemeData lerp(MacosThemeData a, MacosThemeData b, double t) {
     return MacosThemeData.raw(
@@ -337,6 +343,8 @@ class MacosThemeData with Diagnosticable {
       visualDensity: VisualDensity.lerp(a.visualDensity, b.visualDensity, t),
       scrollbarTheme:
           ScrollbarThemeData.lerp(a.scrollbarTheme, b.scrollbarTheme, t),
+      macosIconButtonTheme: MacosIconButtonThemeData.lerp(
+          a.macosIconButtonTheme, b.macosIconButtonTheme, t),
     );
   }
 
@@ -352,6 +360,7 @@ class MacosThemeData with Diagnosticable {
     TooltipThemeData? tooltipTheme,
     VisualDensity? visualDensity,
     ScrollbarThemeData? scrollbarTheme,
+    MacosIconButtonThemeData? macosIconButtonTheme,
   }) {
     return MacosThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -364,6 +373,7 @@ class MacosThemeData with Diagnosticable {
       tooltipTheme: this.tooltipTheme.copyWith(),
       visualDensity: visualDensity ?? this.visualDensity,
       scrollbarTheme: scrollbarTheme ?? this.scrollbarTheme,
+      macosIconButtonTheme: macosIconButtonTheme ?? this.macosIconButtonTheme,
     );
   }
 
@@ -386,6 +396,15 @@ class MacosThemeData with Diagnosticable {
     ));
     properties.add(
       DiagnosticsProperty<TooltipThemeData>('tooltipTheme', tooltipTheme),
+    );
+    properties.add(
+      DiagnosticsProperty<ScrollbarThemeData>('scrollbarTheme', scrollbarTheme),
+    );
+    properties.add(
+      DiagnosticsProperty<MacosIconButtonThemeData>(
+        'macosIconButtonTheme',
+        macosIconButtonTheme,
+      ),
     );
   }
 }

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -344,7 +344,10 @@ class MacosThemeData with Diagnosticable {
       scrollbarTheme:
           ScrollbarThemeData.lerp(a.scrollbarTheme, b.scrollbarTheme, t),
       macosIconButtonTheme: MacosIconButtonThemeData.lerp(
-          a.macosIconButtonTheme, b.macosIconButtonTheme, t),
+        a.macosIconButtonTheme,
+        b.macosIconButtonTheme,
+        t,
+      ),
     );
   }
 

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -230,12 +230,13 @@ class MacosThemeData with Diagnosticable {
       textStyle: typography.callout,
     );
     scrollbarTheme ??= const ScrollbarThemeData();
-    macosIconButtonThemeData ??= const MacosIconButtonThemeData(
+    macosIconButtonThemeData ??= MacosIconButtonThemeData(
       backgroundColor: MacosColors.transparent,
-      disabledColor:
-          MacosColors.systemGrayColor, // TODO: correct disabled color
+      disabledColor: isDark
+          ? const Color(0xff353535)
+          : const Color(0xffE5E5E5), // TODO: correct disabled color
       shape: BoxShape.circle,
-      boxConstraints: BoxConstraints(
+      boxConstraints: const BoxConstraints(
         minHeight: 20,
         minWidth: 20,
         maxWidth: 30,

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -285,10 +285,7 @@ class MacosThemeData with Diagnosticable {
       MacosThemeData(brightness: Brightness.light);
 
   /// A default dark theme.
-  factory MacosThemeData.dark() => MacosThemeData(
-        brightness: Brightness.dark,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      );
+  factory MacosThemeData.dark() => MacosThemeData(brightness: Brightness.dark);
 
   /// The default color theme. Same as [ThemeData.light].
   ///

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -241,7 +241,7 @@ packages:
       name: native_context_menu
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+1"
+    version: "0.1.2+2"
   node_preamble:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.9.0
+version: 0.9.1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  native_context_menu: ^0.1.2+1
+  native_context_menu: ^0.1.2+2
 
 dev_dependencies:
   flutter_test:

--- a/test/theme/icon_button_theme_test.dart
+++ b/test/theme/icon_button_theme_test.dart
@@ -81,7 +81,7 @@ void main() {
 
     final theme = MacosIconButtonTheme.of(capturedContext);
     expect(theme.backgroundColor, MacosColors.transparent);
-    expect(theme.disabledColor, MacosColors.systemGrayColor);
+    expect(theme.disabledColor, const Color(0xffE5E5E5));
   });
 }
 

--- a/test/theme/icon_button_theme_test.dart
+++ b/test/theme/icon_button_theme_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/library.dart';
+
+void main() {
+  testWidgets('copyWith, ==, hashcode basics', (tester) async {
+    expect(
+      const MacosIconButtonThemeData(),
+      const MacosIconButtonThemeData().copyWith(),
+    );
+    expect(
+      const MacosIconButtonThemeData().hashCode,
+      const MacosIconButtonThemeData().copyWith().hashCode,
+    );
+  });
+
+  test('lerps from light to dark', () {
+    final actual = MacosIconButtonThemeData.lerp(
+      _iconButtonTheme,
+      _iconButtonThemeDark,
+      1,
+    );
+
+    expect(actual, _iconButtonThemeDark);
+  });
+
+  test('lerps from dark to light', () {
+    final actual = MacosIconButtonThemeData.lerp(
+      _iconButtonThemeDark,
+      _iconButtonTheme,
+      1,
+    );
+
+    expect(actual, _iconButtonTheme);
+  });
+
+  testWidgets('debugFillProperties', (tester) async {
+    final builder = DiagnosticPropertiesBuilder();
+    const MacosIconButtonThemeData().debugFillProperties(builder);
+
+    final description = builder.properties
+        .where((node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((node) => node.toString())
+        .toList();
+
+    expect(
+      description,
+      [
+        'backgroundColor: null',
+        'disabledColor: null',
+        'shape: null',
+        'borderRadius: null',
+        'boxConstraints: null',
+      ],
+    );
+  });
+
+  testWidgets('Default values in widget tree', (tester) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MacosApp(
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, scrollController) {
+                  capturedContext = context;
+                  return MacosIconButton(
+                    icon: const Icon(CupertinoIcons.add),
+                    onPressed: () {},
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final theme = MacosIconButtonTheme.of(capturedContext);
+    expect(theme.backgroundColor, MacosColors.transparent);
+    expect(theme.disabledColor, MacosColors.systemGrayColor);
+  });
+}
+
+final _iconButtonTheme = MacosIconButtonThemeData(
+  backgroundColor: MacosColors.transparent,
+  disabledColor: MacosColors.systemGrayColor.color,
+);
+
+final _iconButtonThemeDark = MacosIconButtonThemeData(
+  backgroundColor: MacosColors.systemBlueColor.color,
+  disabledColor: MacosColors.systemGrayColor.darkColor,
+);


### PR DESCRIPTION
This PR adds a number of theming enhancements related to `MacosIconButton`

* Added top-level theming for `MacosIconButton`
  * Introduces the `MacosIconButtonTheme` InheritedTheme and the `MacosIconButtonThemeData` theme class
* Updates `MacosThemeData` and `MacosIconButton` to use the new `MacosIconButtonThemeData`
* Removes an unnecessary setting of VisualDensity from `MacosThemeData.dark()`

Closes #108 

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->