### PR TITLE
0.10.0 - `MacosIcon`, `MacosIconTheme`, and `MacosIconThemeData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.10.0]
+* New widget - `MacosIcon`! `MacosIcon` is identical to regular icons, with the exception that it respects a `MacosTheme`. Also includes corresponding theme classes
+* `MacosThemeData` now sets a global, configurable `iconTheme` for `MacosIcon`s 
+
 ## [0.9.3]
 * Update to `PushButton`:
   * Added `isSecondary` property

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,9 @@ The default branch for this project is `dev`. Your work should take place in a b
 from here. `stable` is reserved for releases to pub.dev. All pull requests should therefore
 target `dev`.
 
+### Commit style
+This repository uses [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Please ensure that you use them!
+
 ### Versioning
 
 `macos_ui` uses semantic versioning. However, at this time (Apr 17, 2021), `macos_ui` is still a 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ is lower than 130
   - [MacosWindow](#macoswindow)
   - [MacosScaffold](#macosscaffold)
   - [MacosListTile](#MacosListTile)
+- [Icons](#icons)
+  - [MacosIcon](#MacosIcon)
 - [Buttons](#buttons)
   - [MacosCheckbox](#macoscheckbox)
   - [HelpButton](#helpbutton)
@@ -140,6 +142,21 @@ MacosListTile(
       color: MacosColors.systemGrayColor,
     ),
   ),
+),
+```
+
+# Icons
+
+## MacosIcon
+
+A `MacosIcon` is identical to a regular `Icon` in every way with one exception - it respects
+a `MacosTheme`. Use it the same way you would a regular icon:
+
+```dart
+MacosIcon(
+  CupertinoIcons.add,
+  // color: CupertinoColors.activeBlue.color,
+  // size: 20,
 ),
 ```
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,7 +59,10 @@ class _DemoState extends State<Demo> {
     const FieldsPage(),
     const ColorsPage(),
     const ContextMenusPage(),
-    const Center(child: Text('Disclosure item 3')),
+    const Center(
+        child: MacosIcon(
+      CupertinoIcons.add,
+    )),
     const DialogsPage(),
   ];
 
@@ -81,7 +84,7 @@ class _DemoState extends State<Demo> {
         bottom: const Padding(
           padding: EdgeInsets.all(16.0),
           child: MacosListTile(
-            leading: Icon(CupertinoIcons.profile_circled),
+            leading: MacosIcon(CupertinoIcons.profile_circled),
             title: Text('Tim Apple'),
             subtitle: Text('tim@apple.com'),
           ),
@@ -93,36 +96,36 @@ class _DemoState extends State<Demo> {
             scrollController: controller,
             items: [
               const SidebarItem(
-                leading: Icon(CupertinoIcons.square_on_circle),
+                leading: MacosIcon(CupertinoIcons.square_on_circle),
                 label: Text('Buttons'),
               ),
               const SidebarItem(
-                leading: Icon(CupertinoIcons.arrow_2_circlepath),
+                leading: MacosIcon(CupertinoIcons.arrow_2_circlepath),
                 label: Text('Indicators'),
               ),
               const SidebarItem(
-                leading: Icon(CupertinoIcons.textbox),
+                leading: MacosIcon(CupertinoIcons.textbox),
                 label: Text('Fields'),
               ),
               const SidebarItem(
                 label: Text('Disclosure'),
                 disclosureItems: [
                   SidebarItem(
-                    leading: Icon(CupertinoIcons.infinite),
+                    leading: MacosIcon(CupertinoIcons.infinite),
                     label: Text('Colors'),
                   ),
                   SidebarItem(
-                    leading: Icon(CupertinoIcons.heart),
+                    leading: MacosIcon(CupertinoIcons.heart),
                     label: Text('Context Menus'),
                   ),
                   SidebarItem(
-                    leading: Icon(CupertinoIcons.infinite),
+                    leading: MacosIcon(CupertinoIcons.infinite),
                     label: Text('Item 3'),
                   ),
                 ],
               ),
               const SidebarItem(
-                leading: Icon(CupertinoIcons.rectangle),
+                leading: MacosIcon(CupertinoIcons.rectangle),
                 label: Text('Dialogs & Sheets'),
               ),
             ],

--- a/example/lib/pages/buttons.dart
+++ b/example/lib/pages/buttons.dart
@@ -20,7 +20,7 @@ class _ButtonsPageState extends State<ButtonsPage> {
         actions: [
           MacosIconButton(
             backgroundColor: MacosColors.transparent,
-            icon: const Icon(
+            icon: const MacosIcon(
               CupertinoIcons.sidebar_left,
               color: MacosColors.systemGrayColor,
             ),
@@ -71,7 +71,7 @@ class _ButtonsPageState extends State<ButtonsPage> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     MacosIconButton(
-                      icon: const Icon(
+                      icon: const MacosIcon(
                         CupertinoIcons.star_fill,
                         color: Colors.white,
                       ),
@@ -81,7 +81,7 @@ class _ButtonsPageState extends State<ButtonsPage> {
                     ),
                     const SizedBox(width: 8),
                     const MacosIconButton(
-                      icon: Icon(
+                      icon: MacosIcon(
                         CupertinoIcons.plus_app,
                         color: Colors.white,
                       ),
@@ -90,7 +90,7 @@ class _ButtonsPageState extends State<ButtonsPage> {
                     ),
                     const SizedBox(width: 8),
                     MacosIconButton(
-                      icon: const Icon(
+                      icon: const MacosIcon(
                         CupertinoIcons.minus_square,
                         color: Colors.white,
                       ),

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -249,7 +249,7 @@ class MacosuiSheet extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 const MacosListTile(
-                  leading: Icon(CupertinoIcons.lightbulb),
+                  leading: MacosIcon(CupertinoIcons.lightbulb),
                   title: Text(
                     'A robust library of Flutter components for macOS',
                     //style: MacosTheme.of(context).typography.headline,
@@ -265,7 +265,7 @@ class MacosuiSheet extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 const MacosListTile(
-                  leading: Icon(CupertinoIcons.bolt),
+                  leading: MacosIcon(CupertinoIcons.bolt),
                   title: Text(
                     'Create beautiful macOS applications in minutes',
                     //style: MacosTheme.of(context).typography.headline,

--- a/example/lib/pages/fields.dart
+++ b/example/lib/pages/fields.dart
@@ -29,7 +29,7 @@ class _FieldsPageState extends State<FieldsPage> {
                         horizontal: 4.0,
                         vertical: 2.0,
                       ),
-                      child: Icon(CupertinoIcons.search),
+                      child: MacosIcon(CupertinoIcons.search),
                     ),
                     placeholder: 'Type some text here',
 
@@ -46,7 +46,7 @@ class _FieldsPageState extends State<FieldsPage> {
                   child: MacosTextField.borderless(
                     prefix: Padding(
                       padding: EdgeInsets.symmetric(horizontal: 4.0),
-                      child: Icon(CupertinoIcons.search),
+                      child: MacosIcon(CupertinoIcons.search),
                     ),
                     placeholder: 'Type some text here',
 

--- a/example/lib/pages/indicators.dart
+++ b/example/lib/pages/indicators.dart
@@ -49,7 +49,7 @@ class _IndicatorsPageState extends State<IndicatorsPage> {
                 ),
                 const SizedBox(height: 20),
                 const Label(
-                  icon: Icon(CupertinoIcons.tag),
+                  icon: MacosIcon(CupertinoIcons.tag),
                   text: SelectableText('A determinate progress circle: '),
                   child: ProgressCircle(value: 50),
                 ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.3"
+    version: "0.10.0"
   matcher:
     dependency: transitive
     description:

--- a/lib/macos_ui.dart
+++ b/lib/macos_ui.dart
@@ -21,6 +21,7 @@ export 'src/buttons/radio_button.dart';
 export 'src/buttons/switch.dart';
 export 'src/dialogs/macos_alert_dialog.dart';
 export 'src/fields/text_field.dart';
+export 'src/icon/macos_icon.dart';
 export 'src/indicators/capacity_indicators.dart';
 export 'src/indicators/progress_indicators.dart';
 export 'src/indicators/rating_indicator.dart';

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -349,7 +349,7 @@ class MacosIconThemeData with Diagnosticable {
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
     return other is MacosIconThemeData &&
-        other.color == color &&
+        other.color?.value == color?.value &&
         other.opacity == opacity &&
         other.size == size;
   }

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -336,7 +336,8 @@ class MacosIconThemeData with Diagnosticable {
   /// Linearly interpolate between two icon theme data objects.
   ///
   /// {@macro dart.ui.shadow.lerp}
-  static MacosIconThemeData lerp(MacosIconThemeData? a, MacosIconThemeData? b, double t) {
+  static MacosIconThemeData lerp(
+      MacosIconThemeData? a, MacosIconThemeData? b, double t) {
     return MacosIconThemeData(
       color: Color.lerp(a?.color, b?.color, t),
       opacity: ui.lerpDouble(a?.opacity, b?.opacity, t),

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -2,6 +2,7 @@ import 'dart:ui' as ui show lerpDouble;
 
 import 'package:flutter/foundation.dart';
 import 'package:macos_ui/src/library.dart';
+import 'package:macos_ui/src/theme/macos_theme.dart';
 
 /// An Icon widget that respects a macOS icon theme.
 class MacosIcon extends StatelessWidget {
@@ -230,7 +231,7 @@ class MacosIconTheme extends InheritedTheme {
   static MacosIconThemeData _getInheritedIconThemeData(BuildContext context) {
     final MacosIconTheme? iconTheme =
         context.dependOnInheritedWidgetOfExactType<MacosIconTheme>();
-    return iconTheme?.data ?? const MacosIconThemeData.fallback();
+    return iconTheme?.data ?? MacosTheme.of(context).iconTheme;
   }
 
   @override
@@ -335,8 +336,8 @@ class MacosIconThemeData with Diagnosticable {
   /// Linearly interpolate between two icon theme data objects.
   ///
   /// {@macro dart.ui.shadow.lerp}
-  static IconThemeData lerp(IconThemeData? a, IconThemeData? b, double t) {
-    return IconThemeData(
+  static MacosIconThemeData lerp(MacosIconThemeData? a, MacosIconThemeData? b, double t) {
+    return MacosIconThemeData(
       color: Color.lerp(a?.color, b?.color, t),
       opacity: ui.lerpDouble(a?.opacity, b?.opacity, t),
       size: ui.lerpDouble(a?.size, b?.size, t),

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -337,7 +337,10 @@ class MacosIconThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static MacosIconThemeData lerp(
-      MacosIconThemeData? a, MacosIconThemeData? b, double t) {
+    MacosIconThemeData? a,
+    MacosIconThemeData? b,
+    double t,
+  ) {
     return MacosIconThemeData(
       color: Color.lerp(a?.color, b?.color, t),
       opacity: ui.lerpDouble(a?.opacity, b?.opacity, t),

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -1,0 +1,365 @@
+import 'dart:ui' as ui show lerpDouble;
+
+import 'package:flutter/foundation.dart';
+import 'package:macos_ui/src/library.dart';
+
+/// An Icon widget that respects a macOS icon theme.
+class MacosIcon extends StatelessWidget {
+  /// Creates an icon.
+  ///
+  /// The [size] and [color] default to the value given by the current
+  /// [MacosIconTheme].
+  const MacosIcon(
+    this.icon, {
+    Key? key,
+    this.size,
+    this.color,
+    this.semanticLabel,
+    this.textDirection,
+  }) : super(key: key);
+
+  /// The icon to display. The available icons are described in [Icons]
+  /// and [CupertinoIcons].
+  ///
+  /// The icon can be null, in which case the widget will render as an empty
+  /// space of the specified [size].
+  final IconData? icon;
+
+  /// The size of the icon in logical pixels.
+  ///
+  /// Icons occupy a square with width and height equal to size.
+  ///
+  /// Defaults to the current [MacosIconTheme] size, if any. If there is no
+  /// [MacosIconTheme], or it does not specify an explicit size, then it
+  /// defaults to 24.0.
+  final double? size;
+
+  /// The color to use when drawing the icon.
+  ///
+  /// Defaults to the current [MacosIconTheme] color, if any.
+  ///
+  /// The color (whether specified explicitly here or obtained from the
+  /// [MacosIconTheme]) will be further adjusted by the opacity of the current
+  /// [MacosIconTheme], if any.
+  ///
+  /// If no [MacosIconTheme] and no [MacosTheme] is specified, icons will
+  /// default to the color value of [CupertinoColors.activeBlue.color].
+  ///
+  /// See [MacosTheme] to set the current theme and [MacosThemeData.brightness]
+  /// for setting the current theme's brightness.
+  final Color? color;
+
+  /// Semantic label for the icon.
+  ///
+  /// Announced in accessibility modes (e.g TalkBack/VoiceOver).
+  /// This label does not show in the UI.
+  ///
+  ///  * [SemanticsProperties.label], which is set to [semanticLabel] in the
+  ///    underlying	 [Semantics] widget.
+  final String? semanticLabel;
+
+  /// The text direction to use for rendering the icon.
+  ///
+  /// If this is null, the ambient [Directionality] is used instead.
+  ///
+  /// Some icons follow the reading direction. For example, "back" buttons point
+  /// left in left-to-right environments and right in right-to-left
+  /// environments. Such icons have their [IconData.matchTextDirection] field
+  /// set to true, and the [MacosIcon] widget uses the [textDirection] to
+  /// determine the orientation in which to draw the icon.
+  ///
+  /// This property has no effect if the [icon]'s [IconData.matchTextDirection]
+  /// field is false, but for consistency a text direction value must always be
+  /// specified, either directly using this property or using [Directionality].
+  final TextDirection? textDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(this.textDirection != null || debugCheckHasDirectionality(context));
+    final TextDirection textDirection =
+        this.textDirection ?? Directionality.of(context);
+
+    final iconTheme = MacosIconTheme.of(context);
+
+    final iconSize = size ?? iconTheme.size;
+
+    if (icon == null) {
+      return Semantics(
+        label: semanticLabel,
+        child: SizedBox(
+          width: iconSize,
+          height: iconSize,
+        ),
+      );
+    }
+
+    final iconOpacity = iconTheme.opacity ?? 1.0;
+    Color iconColor = color ?? iconTheme.color!;
+    if (iconOpacity != 1.0)
+      iconColor = iconColor.withOpacity(iconColor.opacity * iconOpacity);
+
+    Widget iconWidget = RichText(
+      overflow: TextOverflow.visible,
+      textDirection: textDirection,
+      text: TextSpan(
+        text: String.fromCharCode(icon!.codePoint),
+        style: TextStyle(
+          inherit: false,
+          color: iconColor,
+          fontSize: iconSize,
+          fontFamily: icon!.fontFamily,
+          package: icon!.fontPackage,
+        ),
+      ),
+    );
+
+    if (icon!.matchTextDirection) {
+      switch (textDirection) {
+        case TextDirection.rtl:
+          iconWidget = Transform(
+            transform: Matrix4.identity()..scale(-1.0, 1.0, 1.0),
+            alignment: Alignment.center,
+            transformHitTests: false,
+            child: iconWidget,
+          );
+          break;
+        case TextDirection.ltr:
+          break;
+      }
+    }
+
+    return Semantics(
+      label: semanticLabel,
+      child: ExcludeSemantics(
+        child: SizedBox(
+          width: iconSize,
+          height: iconSize,
+          child: Center(
+            child: iconWidget,
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IconDataProperty(
+      'icon',
+      icon,
+      ifNull: '<empty>',
+      showName: false,
+    ));
+    properties.add(DoubleProperty('size', size, defaultValue: null));
+    properties.add(ColorProperty('color', color, defaultValue: null));
+  }
+}
+
+/// Controls the default color, opacity, and size of icons in a widget subtree.
+///
+/// The icon theme is honored by [MacosIcon] widgets.
+class MacosIconTheme extends InheritedTheme {
+  /// Creates an icon theme that controls the color, opacity, and size of
+  /// descendant widgets.
+  ///
+  /// Both [data] and [child] arguments must not be null.
+  const MacosIconTheme({
+    Key? key,
+    required this.data,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  /// Creates an icon theme that controls the color, opacity, and size of
+  /// descendant widgets, and merges in the current icon theme, if any.
+  ///
+  /// The [data] and [child] arguments must not be null.
+  static Widget merge({
+    Key? key,
+    required IconThemeData data,
+    required Widget child,
+  }) {
+    return Builder(
+      builder: (BuildContext context) {
+        return MacosIconTheme(
+          key: key,
+          data: _getInheritedIconThemeData(context).merge(data),
+          child: child,
+        );
+      },
+    );
+  }
+
+  /// The color, opacity, and size to use for icons in this subtree.
+  final MacosIconThemeData data;
+
+  /// The data from the closest instance of this class that encloses the given
+  /// context, if any.
+  ///
+  /// If there is no ambient icon theme, defaults to [MacosIconThemeData.fallback].
+  /// The returned [MacosIconThemeData] is concrete (all values are non-null; see
+  /// [MacosIconThemeData.isConcrete]). Any properties on the ambient icon theme that
+  /// are null get defaulted to the values specified on
+  /// [MacosIconThemeData.fallback].
+  ///
+  /// The [MacosTheme] widget from the `macos_ui` library introduces a [MacosIconTheme]
+  /// widget set to the [MacosThemeData.iconTheme], so in a macos_ui-style
+  /// application, this will typically default to the icon theme from the
+  /// ambient [MacosTheme].
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// MacosIconThemeData theme = MacosIconTheme.of(context);
+  /// ```
+  static MacosIconThemeData of(BuildContext context) {
+    final MacosIconThemeData iconThemeData =
+        _getInheritedIconThemeData(context).resolve(context);
+    return iconThemeData.isConcrete
+        ? iconThemeData
+        : iconThemeData.copyWith(
+            size:
+                iconThemeData.size ?? const MacosIconThemeData.fallback().size,
+            color: iconThemeData.color ??
+                const MacosIconThemeData.fallback().color,
+            opacity: iconThemeData.opacity ??
+                const MacosIconThemeData.fallback().opacity,
+          );
+  }
+
+  static MacosIconThemeData _getInheritedIconThemeData(BuildContext context) {
+    final MacosIconTheme? iconTheme =
+        context.dependOnInheritedWidgetOfExactType<MacosIconTheme>();
+    return iconTheme?.data ?? const MacosIconThemeData.fallback();
+  }
+
+  @override
+  bool updateShouldNotify(MacosIconTheme oldWidget) => data != oldWidget.data;
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return MacosIconTheme(data: data, child: child);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    data.debugFillProperties(properties);
+  }
+}
+
+/// Defines the color, opacity, and size of icons.
+///
+/// Used by [MacosIconTheme] to control the color, opacity, and size of icons in a
+/// widget subtree.
+///
+/// To obtain the current icon theme, use [MacosIconTheme.of]. To convert an icon
+/// theme to a version with all the fields filled in, use [new
+/// MacosIconThemeData.fallback].
+class MacosIconThemeData with Diagnosticable {
+  /// Creates an icon theme data.
+  ///
+  /// The opacity applies to both explicit and default icon colors. The value
+  /// is clamped between 0.0 and 1.0.
+  const MacosIconThemeData({
+    this.color,
+    double? opacity,
+    this.size,
+  }) : _opacity = opacity;
+
+  /// Creates an icon theme with some reasonable default values.
+  ///
+  /// The [color] is blue, the [opacity] is 1.0, and the [size] is 24.0.
+  const MacosIconThemeData.fallback()
+      : color = const Color.fromARGB(255, 0, 122, 255),
+        _opacity = 1.0,
+        size = 24.0;
+
+  /// Creates a copy of this icon theme but with the given fields replaced with
+  /// the new values.
+  MacosIconThemeData copyWith({
+    Color? color,
+    double? opacity,
+    double? size,
+  }) {
+    return MacosIconThemeData(
+      color: color ?? this.color,
+      opacity: opacity ?? this.opacity,
+      size: size ?? this.size,
+    );
+  }
+
+  /// Returns a new icon theme that matches this icon theme but with some values
+  /// replaced by the non-null parameters of the given icon theme. If the given
+  /// icon theme is null, simply returns this icon theme.
+  MacosIconThemeData merge(IconThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      color: other.color,
+      opacity: other.opacity,
+      size: other.size,
+    );
+  }
+
+  /// Called by [MacosIconTheme.of] to convert this instance to an [MacosIconThemeData]
+  /// that fits the given [BuildContext].
+  ///
+  /// This method gives the ambient [MacosIconThemeData] a chance to update itself,
+  /// after it's been retrieved by [MacosIconTheme.of], and before being returned as
+  /// the final result. For instance, [CupertinoIconThemeData] overrides this method
+  /// to resolve [color], in case [color] is a [CupertinoDynamicColor] and needs
+  /// to be resolved against the given [BuildContext] before it can be used as a
+  /// regular [Color].
+  ///
+  /// The default implementation returns this [MacosIconThemeData] as-is.
+  ///
+  /// See also:
+  ///
+  ///  * [CupertinoIconThemeData.resolve] an implementation that resolves
+  ///    the color of [CupertinoIconThemeData] before returning.
+  MacosIconThemeData resolve(BuildContext context) => this;
+
+  /// Whether all the properties of this object are non-null.
+  bool get isConcrete => color != null && opacity != null && size != null;
+
+  /// The default color for icons.
+  final Color? color;
+
+  /// An opacity to apply to both explicit and default icon colors.
+  double? get opacity => _opacity?.clamp(0.0, 1.0);
+  final double? _opacity;
+
+  /// The default size for icons.
+  final double? size;
+
+  /// Linearly interpolate between two icon theme data objects.
+  ///
+  /// {@macro dart.ui.shadow.lerp}
+  static IconThemeData lerp(IconThemeData? a, IconThemeData? b, double t) {
+    return IconThemeData(
+      color: Color.lerp(a?.color, b?.color, t),
+      opacity: ui.lerpDouble(a?.opacity, b?.opacity, t),
+      size: ui.lerpDouble(a?.size, b?.size, t),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) return false;
+    return other is IconThemeData &&
+        other.color == color &&
+        other.opacity == opacity &&
+        other.size == size;
+  }
+
+  @override
+  int get hashCode => hashValues(color, opacity, size);
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(ColorProperty('color', color, defaultValue: null));
+    properties.add(DoubleProperty('opacity', opacity, defaultValue: null));
+    properties.add(DoubleProperty('size', size, defaultValue: null));
+  }
+}

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -348,7 +348,7 @@ class MacosIconThemeData with Diagnosticable {
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) return false;
-    return other is IconThemeData &&
+    return other is MacosIconThemeData &&
         other.color == color &&
         other.opacity == opacity &&
         other.size == size;

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -334,7 +334,9 @@ class MacosThemeData with Diagnosticable {
   /// The default style for [MacosScrollbar]s below the overall [MacosTheme]
   final ScrollbarThemeData scrollbarTheme;
 
+  /// The default style for [MacosIconButton]s below the overall [MacosTheme]
   final MacosIconButtonThemeData macosIconButtonTheme;
+
 
   /// Linearly interpolate between two themes.
   static MacosThemeData lerp(MacosThemeData a, MacosThemeData b, double t) {

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/icon/macos_icon.dart';
 import 'package:macos_ui/src/library.dart';
 
 /// Applies a macOS-style theme to descendant macOS widgets.
@@ -196,6 +197,7 @@ class MacosThemeData with Diagnosticable {
     VisualDensity? visualDensity,
     ScrollbarThemeData? scrollbarTheme,
     MacosIconButtonThemeData? macosIconButtonThemeData,
+    MacosIconThemeData? iconTheme,
   }) {
     final Brightness _brightness = brightness ?? Brightness.light;
     final bool isDark = _brightness == Brightness.dark;
@@ -246,6 +248,13 @@ class MacosThemeData with Diagnosticable {
 
     visualDensity ??= VisualDensity.adaptivePlatformDensity;
 
+    iconTheme ??= MacosIconThemeData(
+      color: isDark
+          ? CupertinoColors.activeBlue.darkColor
+          : CupertinoColors.activeBlue.color,
+      size: 20,
+    );
+
     return MacosThemeData.raw(
       brightness: _brightness,
       primaryColor: primaryColor,
@@ -258,6 +267,7 @@ class MacosThemeData with Diagnosticable {
       visualDensity: visualDensity,
       scrollbarTheme: scrollbarTheme,
       macosIconButtonTheme: macosIconButtonThemeData,
+      iconTheme: iconTheme,
     );
   }
 
@@ -279,6 +289,7 @@ class MacosThemeData with Diagnosticable {
     required this.visualDensity,
     required this.scrollbarTheme,
     required this.macosIconButtonTheme,
+    required this.iconTheme,
   });
 
   /// A default light theme.
@@ -337,6 +348,8 @@ class MacosThemeData with Diagnosticable {
   /// The default style for [MacosIconButton]s below the overall [MacosTheme]
   final MacosIconButtonThemeData macosIconButtonTheme;
 
+  /// The default style for [MacosIcon]s below the overall [MacosTheme]
+  final MacosIconThemeData iconTheme;
 
   /// Linearly interpolate between two themes.
   static MacosThemeData lerp(MacosThemeData a, MacosThemeData b, double t) {
@@ -359,6 +372,7 @@ class MacosThemeData with Diagnosticable {
         b.macosIconButtonTheme,
         t,
       ),
+      iconTheme: MacosIconThemeData.lerp(a.iconTheme, b.iconTheme, t),
     );
   }
 
@@ -375,6 +389,7 @@ class MacosThemeData with Diagnosticable {
     VisualDensity? visualDensity,
     ScrollbarThemeData? scrollbarTheme,
     MacosIconButtonThemeData? macosIconButtonTheme,
+    MacosIconThemeData? iconTheme,
   }) {
     return MacosThemeData.raw(
       brightness: brightness ?? this.brightness,
@@ -388,6 +403,7 @@ class MacosThemeData with Diagnosticable {
       visualDensity: visualDensity ?? this.visualDensity,
       scrollbarTheme: scrollbarTheme ?? this.scrollbarTheme,
       macosIconButtonTheme: macosIconButtonTheme ?? this.macosIconButtonTheme,
+      iconTheme: iconTheme ?? this.iconTheme,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.9.3
+version: 0.10.0
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/test/theme/icon_theme_test.dart
+++ b/test/theme/icon_theme_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/library.dart';
+
+void main() {
+  test('copyWith, ==, hashcode basics', () {
+    expect(
+      const MacosIconThemeData(),
+      const MacosIconThemeData().copyWith(),
+    );
+    expect(
+      const MacosIconThemeData().hashCode,
+      const MacosIconThemeData().copyWith().hashCode,
+    );
+  });
+
+  test('lerps from light to dark', () {
+    final actual = MacosIconThemeData.lerp(
+      _iconTheme,
+      _iconThemeDark,
+      1,
+    );
+
+    expect(actual, _iconThemeDark);
+  });
+
+  test('lerps from dark to light', () {
+    final actual = MacosIconThemeData.lerp(
+      _iconThemeDark,
+      _iconTheme,
+      1,
+    );
+
+    expect(actual, _iconTheme);
+  });
+
+  testWidgets('debugFillProperties', (tester) async {
+    final builder = DiagnosticPropertiesBuilder();
+    const MacosIconThemeData(
+      color: MacosColors.white,
+      size: 20,
+      opacity: 0.0,
+    ).debugFillProperties(builder);
+
+    final description = builder.properties
+        .where((node) => !node.isFiltered(DiagnosticLevel.info))
+        .map((node) => node.toString())
+        .toList();
+
+    expect(
+      description,
+      [
+        'color: Color(0xffffffff)',
+        'opacity: 0.0',
+        'size: 20.0',
+      ],
+    );
+  });
+
+  testWidgets('Default values in widget tree', (tester) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MacosApp(
+        home: MacosWindow(
+          child: MacosScaffold(
+            children: [
+              ContentArea(
+                builder: (context, scrollController) {
+                  capturedContext = context;
+                  return const MacosIcon(
+                    CupertinoIcons.add,
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final theme = MacosIconTheme.of(capturedContext);
+    expect(theme.color, CupertinoColors.activeBlue.color);
+    expect(theme.size, 20);
+  });
+}
+
+const _iconTheme = MacosIconThemeData(
+  color: MacosColors.black,
+);
+
+const _iconThemeDark = MacosIconThemeData(
+  color: MacosColors.white,
+);


### PR DESCRIPTION
This PR adds a new widget, `MacosIcon`, and corresponding theme classes. It updates `MacosThemeData` to make use of `MacosIconThemeData` so that a global icon theme can be set.

A `MacosIcon` is identical to a regular `Icon` widget, except it calls `MacosIconTheme.of(context)` to get a parent theme rather than `IconThemeData`, which obviously does not respect `MacosThemeData`

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [ ] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added tests for new code
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->