### PR TITLE
Sidebar transparency effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.10.1]
+* Added support for transparent sidebar
+
 ## [0.10.0+1]
 * Update `native_context_menu` dependency
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ class MainFlutterWindow: NSWindow {
     self.isMovableByWindowBackground = true
     self.styleMask.insert(NSWindow.StyleMask.fullSizeContentView)
 
+    self.isOpaque = false
+    self.backgroundColor = .clear
+    let contentView = contentViewController!.view;
+    let superView = contentView.superview!;
+    let blurView = NSVisualEffectView()
+    blurView.frame = superView.bounds
+    blurView.autoresizingMask = [.width, .height]
+    blurView.blendingMode = NSVisualEffectView.BlendingMode.behindWindow
+    if #available(macOS 10.14, *) {
+      blurView.material = .underWindowBackground
+    }
+    superView.replaceSubview(contentView, with: blurView)
+    blurView.addSubview(contentView)
+
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
 

--- a/example/macos/Runner/MainFlutterWindow.swift
+++ b/example/macos/Runner/MainFlutterWindow.swift
@@ -22,6 +22,20 @@ class MainFlutterWindow: NSWindow {
     self.isMovableByWindowBackground = true
     self.styleMask.insert(NSWindow.StyleMask.fullSizeContentView)
 
+    self.isOpaque = false
+    self.backgroundColor = .clear
+    let contentView = contentViewController!.view;
+    let superView = contentView.superview!;
+    let blurView = NSVisualEffectView()
+    blurView.frame = superView.bounds
+    blurView.autoresizingMask = [.width, .height]
+    blurView.blendingMode = NSVisualEffectView.BlendingMode.behindWindow
+    if #available(macOS 10.14, *) {
+      blurView.material = .underWindowBackground
+    }
+    superView.replaceSubview(contentView, with: blurView)
+    blurView.addSubview(contentView)
+
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:macos_ui/src/indicators/scrollbar.dart';
 import 'package:macos_ui/src/layout/content_area.dart';
@@ -95,10 +96,18 @@ class _MacosWindowState extends State<MacosWindow> {
     late Color sidebarBackgroundColor;
     Color dividerColor = theme.dividerColor;
 
-    // Only show blurry, transparent sidebar when platform brightness and app
-    // brightness are the same, otherwise it looks awful
-    if (MediaQuery.of(context).platformBrightness.isDark ==
-        theme.brightness.isDark) {
+    final isMac = !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
+
+    // Respect the sidebar color override from parent if one is given
+    if (widget.sidebar?.decoration?.color != null) {
+      sidebarBackgroundColor = widget.sidebar!.decoration!.color!;
+    } else if (isMac &&
+        MediaQuery.of(context).platformBrightness.isDark ==
+            theme.brightness.isDark) {
+      // Only show blurry, transparent sidebar when platform brightness and app
+      // brightness are the same, otherwise it looks awful. Also only make the
+      // sidebar transparent on native Mac, or it will just be flat black or
+      // white.
       sidebarBackgroundColor = Colors.transparent;
     } else if (!theme.brightness.isDark) {
       sidebarBackgroundColor = widget.sidebar?.decoration?.color ??

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -97,7 +97,8 @@ class _MacosWindowState extends State<MacosWindow> {
 
     // Only show blurry, transparent sidebar when platform brightness and app
     // brightness are the same, otherwise it looks awful
-    if (MediaQuery.of(context).platformBrightness.isDark == theme.brightness.isDark) {
+    if (MediaQuery.of(context).platformBrightness.isDark ==
+        theme.brightness.isDark) {
       sidebarBackgroundColor = Colors.transparent;
     } else if (!theme.brightness.isDark) {
       sidebarBackgroundColor = widget.sidebar?.decoration?.color ??

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -95,7 +95,11 @@ class _MacosWindowState extends State<MacosWindow> {
     late Color sidebarBackgroundColor;
     Color dividerColor = theme.dividerColor;
 
-    if (!theme.brightness.isDark) {
+    // Only show blurry, transparent sidebar when platform brightness and app
+    // brightness are the same, otherwise it looks awful
+    if (MediaQuery.of(context).platformBrightness.isDark == theme.brightness.isDark) {
+      sidebarBackgroundColor = Colors.transparent;
+    } else if (!theme.brightness.isDark) {
       sidebarBackgroundColor = widget.sidebar?.decoration?.color ??
           CupertinoColors.systemGrey6.color;
     } else {

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -109,12 +109,10 @@ class _MacosWindowState extends State<MacosWindow> {
       // sidebar transparent on native Mac, or it will just be flat black or
       // white.
       sidebarBackgroundColor = Colors.transparent;
-    } else if (!theme.brightness.isDark) {
-      sidebarBackgroundColor = widget.sidebar?.decoration?.color ??
-          CupertinoColors.systemGrey6.color;
     } else {
-      sidebarBackgroundColor = widget.sidebar?.decoration?.color ??
-          CupertinoColors.tertiarySystemBackground.darkColor;
+      sidebarBackgroundColor = theme.brightness.isDark
+          ? CupertinoColors.tertiarySystemBackground.darkColor
+          : CupertinoColors.systemGrey6.color;
     }
 
     final curve = Curves.linearToEaseOut;

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:macos_ui/macos_ui.dart';
-import 'package:macos_ui/src/icon/macos_icon.dart';
 import 'package:macos_ui/src/library.dart';
 
 /// Applies a macOS-style theme to descendant macOS widgets.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.10.0+1
+version: 0.10.1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/test/theme/icon_button_theme_test.dart
+++ b/test/theme/icon_button_theme_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';


### PR DESCRIPTION
<!--

    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioninig issues related to this pull request

-->

This PR adds a transparency effect to the sidebar, as long as system and app brightness match.

Some changes to MainFlutterWindow.swift are necessary, like they were done in the README and the example

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->

### Before PR
<img width="842" alt="before_white" src="https://user-images.githubusercontent.com/77107165/149658031-9f69171e-7757-49ff-a52a-edcd00e65289.png">
<img width="842" alt="before_black" src="https://user-images.githubusercontent.com/77107165/149658036-10837b45-c028-4b1c-820a-939d2a8ae63a.png">

## After PR
<img width="842" alt="after_light" src="https://user-images.githubusercontent.com/77107165/149658040-099b145c-d4d5-4cab-a34e-ae95e03b974d.png">
<img width="842" alt="after_black" src="https://user-images.githubusercontent.com/77107165/149658044-7055aa06-2e2f-4f3d-a613-8c79480a1a8e.png">