### PR TITLE
feat: added padding property to IconButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.12.3]
+* Added `padding` property to `MacosIconButton` and `MacosIconButtonTheme`.
+
 ## [0.12.2]
 * Fixes `MacosThemeData` to properly apply user-defined `pushButtonTheme`, `helpButtonTheme`, and `tooltipTheme` properties.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.12.2"
+    version: "0.12.3"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -375,6 +375,7 @@ class MacosIconButtonThemeData with Diagnosticable {
     BoxShape? shape,
     BorderRadius? borderRadius,
     BoxConstraints? boxConstraints,
+    EdgeInsetsGeometry? padding,
   }) {
     return MacosIconButtonThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -456,6 +457,7 @@ class MacosIconButtonThemeData with Diagnosticable {
       shape: other.shape,
       borderRadius: other.borderRadius,
       boxConstraints: other.boxConstraints,
+      padding: other.padding,
     );
   }
 }

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -118,7 +118,7 @@ class MacosIconButton extends StatefulWidget {
     properties.add(ColorProperty('hoverColor', hoverColor));
     properties.add(DoubleProperty('pressedOpacity', pressedOpacity));
     properties.add(DiagnosticsProperty('alignment', alignment));
-    properties.add(DiagnosticsProperty('padding', padding));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding));
     properties.add(StringProperty('semanticLabel', semanticLabel));
   }
 

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -23,6 +23,7 @@ class MacosIconButton extends StatefulWidget {
       maxWidth: 30,
       maxHeight: 30,
     ),
+    this.padding,
     this.mouseCursor = SystemMouseCursors.basic,
   })  : assert(pressedOpacity == null ||
             (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
@@ -94,6 +95,11 @@ class MacosIconButton extends StatefulWidget {
   ///```
   final BoxConstraints boxConstraints;
 
+  /// The internal padding for the button's [icon].
+  ///
+  /// Defaults to `EdgeInsets.all(8)`.
+  final EdgeInsetsGeometry? padding;
+
   /// The semantic label used by screen readers.
   final String? semanticLabel;
 
@@ -112,6 +118,7 @@ class MacosIconButton extends StatefulWidget {
     properties.add(ColorProperty('hoverColor', hoverColor));
     properties.add(DoubleProperty('pressedOpacity', pressedOpacity));
     properties.add(DiagnosticsProperty('alignment', alignment));
+    properties.add(DiagnosticsProperty('padding', padding));
     properties.add(StringProperty('semanticLabel', semanticLabel));
   }
 
@@ -217,6 +224,8 @@ class MacosIconButtonState extends State<MacosIconButton>
       disabledColor = theme.disabledColor;
     }
 
+    final padding = widget.padding ?? theme.padding ?? const EdgeInsets.all(8);
+
     return MouseRegion(
       cursor: widget.mouseCursor!,
       onEnter: (e) {
@@ -253,7 +262,7 @@ class MacosIconButtonState extends State<MacosIconButton>
                           : backgroundColor,
                 ),
                 child: Padding(
-                  padding: const EdgeInsets.all(8),
+                  padding: padding,
                   child: Align(
                     alignment: widget.alignment,
                     widthFactor: 1.0,
@@ -334,6 +343,7 @@ class MacosIconButtonThemeData with Diagnosticable {
     this.shape,
     this.borderRadius,
     this.boxConstraints,
+    this.padding,
   });
 
   /// The default background color for [MacosIconButton].
@@ -354,6 +364,9 @@ class MacosIconButtonThemeData with Diagnosticable {
   /// The default box constraints for [MacosIconButton].
   final BoxConstraints? boxConstraints;
 
+  /// The default padding for [MacosIconButton].
+  final EdgeInsetsGeometry? padding;
+
   /// Copies this [MacosIconButtonThemeData] into another.
   MacosIconButtonThemeData copyWith({
     Color? backgroundColor,
@@ -370,6 +383,7 @@ class MacosIconButtonThemeData with Diagnosticable {
       shape: shape ?? this.shape,
       borderRadius: borderRadius ?? this.borderRadius,
       boxConstraints: boxConstraints ?? this.boxConstraints,
+      padding: padding ?? this.padding,
     );
   }
 
@@ -389,6 +403,7 @@ class MacosIconButtonThemeData with Diagnosticable {
       borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
       boxConstraints:
           BoxConstraints.lerp(a.boxConstraints, b.boxConstraints, t),
+      padding: EdgeInsetsGeometry.lerp(a.padding, b.padding, t),
     );
   }
 
@@ -402,7 +417,8 @@ class MacosIconButtonThemeData with Diagnosticable {
           hoverColor?.value == other.hoverColor?.value &&
           shape == other.shape &&
           borderRadius == other.borderRadius &&
-          boxConstraints == other.boxConstraints;
+          boxConstraints == other.boxConstraints &&
+          padding == other.padding;
 
   @override
   int get hashCode =>
@@ -411,7 +427,8 @@ class MacosIconButtonThemeData with Diagnosticable {
       hoverColor.hashCode ^
       shape.hashCode ^
       borderRadius.hashCode ^
-      boxConstraints.hashCode;
+      boxConstraints.hashCode ^
+      padding.hashCode;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -424,6 +441,9 @@ class MacosIconButtonThemeData with Diagnosticable {
         .add(DiagnosticsProperty<BorderRadius?>('borderRadius', borderRadius));
     properties.add(
       DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints),
+    );
+    properties.add(
+      DiagnosticsProperty<EdgeInsetsGeometry?>('padding', padding),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.12.2
+version: 0.12.3
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/test/buttons/icon_button_test.dart
+++ b/test/buttons/icon_button_test.dart
@@ -88,6 +88,7 @@ void main() {
         'hoverColor: null',
         'pressedOpacity: 0.4',
         'alignment: Alignment.center',
+        'padding: null',
         'semanticLabel: null',
       ],
     );

--- a/test/theme/icon_button_theme_test.dart
+++ b/test/theme/icon_button_theme_test.dart
@@ -53,6 +53,7 @@ void main() {
         'shape: null',
         'borderRadius: null',
         'boxConstraints: null',
+        'padding: null',
       ],
     );
   });


### PR DESCRIPTION
Previously the padding for `IconButton` was hard-coded to `8`. This PR adds the ability to influence it by adding a `padding` property to both the widget or its theme.

Note that I deliberately did NOT update the changelog because I'm not in charge of deciding what goes in what release and/or actually publishing. I figured I'd leave that to @GroovinChip to add whenever he decides to publish a new release.

## Pre-launch Checklist

- [X] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [X] I have added/updated relevant documentation <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->