### PR TITLE
Add merge methods to `MacosThemeData` and widget-specific `ThemeData` classes (closes #183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.12.2+1]
+* Adds missing `merge` methods to `MacosThemeData` and widget `ThemeData` classes, making it possible to use them properly with any number of user-provided custom properties.
+
 ## [0.12.2]
 * Fixes `MacosThemeData` to properly apply user-defined `pushButtonTheme`, `helpButtonTheme`, and `tooltipTheme` properties.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -73,7 +73,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.12.2"
+    version: "0.12.2+1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/buttons/help_button.dart
+++ b/lib/src/buttons/help_button.dart
@@ -344,4 +344,12 @@ class HelpButtonThemeData with Diagnosticable {
     properties.add(ColorProperty('color', color));
     properties.add(ColorProperty('disabledColor', disabledColor));
   }
+
+  HelpButtonThemeData merge(HelpButtonThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      color: other.color,
+      disabledColor: other.disabledColor,
+    );
+  }
 }

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -426,4 +426,16 @@ class MacosIconButtonThemeData with Diagnosticable {
       DiagnosticsProperty<BoxConstraints?>('boxConstraints', boxConstraints),
     );
   }
+
+  MacosIconButtonThemeData merge(MacosIconButtonThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      backgroundColor: other.backgroundColor,
+      disabledColor: other.disabledColor,
+      hoverColor: other.hoverColor,
+      shape: other.shape,
+      borderRadius: other.borderRadius,
+      boxConstraints: other.boxConstraints,
+    );
+  }
 }

--- a/lib/src/buttons/popup_button.dart
+++ b/lib/src/buttons/popup_button.dart
@@ -1611,4 +1611,13 @@ class MacosPopupButtonThemeData with Diagnosticable {
     properties.add(ColorProperty('backgroundColor', backgroundColor));
     properties.add(ColorProperty('popupColor', popupColor));
   }
+
+  MacosPopupButtonThemeData merge(MacosPopupButtonThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      highlightColor: other.highlightColor,
+      backgroundColor: other.backgroundColor,
+      popupColor: other.popupColor,
+    );
+  }
 }

--- a/lib/src/buttons/push_button.dart
+++ b/lib/src/buttons/push_button.dart
@@ -413,4 +413,13 @@ class PushButtonThemeData with Diagnosticable {
     properties.add(ColorProperty('disabledColor', disabledColor));
     properties.add(ColorProperty('secondaryColor', secondaryColor));
   }
+
+  PushButtonThemeData merge(PushButtonThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      color: other.color,
+      disabledColor: other.disabledColor,
+      secondaryColor: other.secondaryColor,
+    );
+  }
 }

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -177,7 +177,7 @@ class MacosIconTheme extends InheritedTheme {
   /// The [data] and [child] arguments must not be null.
   static Widget merge({
     Key? key,
-    required IconThemeData data,
+    required MacosIconThemeData data,
     required Widget child,
   }) {
     return Builder(
@@ -293,7 +293,7 @@ class MacosIconThemeData with Diagnosticable {
   /// Returns a new icon theme that matches this icon theme but with some values
   /// replaced by the non-null parameters of the given icon theme. If the given
   /// icon theme is null, simply returns this icon theme.
-  MacosIconThemeData merge(IconThemeData? other) {
+  MacosIconThemeData merge(MacosIconThemeData? other) {
     if (other == null) return this;
     return copyWith(
       color: other.color,

--- a/lib/src/indicators/scrollbar.dart
+++ b/lib/src/indicators/scrollbar.dart
@@ -286,6 +286,8 @@ class ScrollbarThemeData with Diagnosticable {
     Color? hoveringThumbColor,
     Color? draggingThumbColor,
     Color? trackColor,
+    Color? hoveringTrackColor,
+    Color? trackBorderColor,
     Color? hoveringTrackBorderColor,
     double? crossAxisMargin,
     double? mainAxisMargin,
@@ -465,6 +467,28 @@ class ScrollbarThemeData with Diagnosticable {
       minThumbLength,
       defaultValue: null,
     ));
+  }
+
+  ScrollbarThemeData merge(ScrollbarThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      thickness: other.thickness,
+      hoveringThickness: other.hoveringThickness,
+      showTrackOnHover: other.showTrackOnHover,
+      isAlwaysShown: other.isAlwaysShown,
+      interactive: other.interactive,
+      radius: other.radius,
+      thumbColor: other.thumbColor,
+      hoveringThumbColor: other.hoveringThumbColor,
+      draggingThumbColor: other.draggingThumbColor,
+      trackColor: other.trackColor,
+      hoveringTrackColor: other.hoveringTrackColor,
+      trackBorderColor: other.trackBorderColor,
+      hoveringTrackBorderColor: other.hoveringTrackBorderColor,
+      crossAxisMargin: other.crossAxisMargin,
+      mainAxisMargin: other.mainAxisMargin,
+      minThumbLength: other.minThumbLength,
+    );
   }
 }
 

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -423,13 +423,13 @@ class TooltipThemeData with Diagnosticable {
 
   /// Copy this tooltip with [style]
   TooltipThemeData copyWith({
-    BoxDecoration? decoration,
+    Decoration? decoration,
     double? height,
     EdgeInsetsGeometry? margin,
     EdgeInsetsGeometry? padding,
     bool? preferBelow,
     Duration? showDuration,
-    TextStyle? testStyle,
+    TextStyle? textStyle,
     double? verticalOffset,
     Duration? waitDuration,
   }) {
@@ -575,6 +575,21 @@ class TooltipThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<Duration>('waitDuration', waitDuration));
     properties.add(DiagnosticsProperty<Duration>('showDuration', showDuration));
     properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle));
+  }
+
+  TooltipThemeData merge(TooltipThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      decoration: other.decoration,
+      height: other.height,
+      margin: other.margin,
+      padding: other.padding,
+      preferBelow: other.preferBelow,
+      showDuration: other.showDuration,
+      textStyle: other.textStyle,
+      verticalOffset: other.verticalOffset,
+      waitDuration: other.waitDuration,
+    );
   }
 }
 

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -271,7 +271,7 @@ class MacosThemeData with Diagnosticable {
           : const Color.fromRGBO(242, 242, 247, 1),
     );
 
-    return MacosThemeData.raw(
+    final defaultData = MacosThemeData.raw(
       brightness: _brightness,
       primaryColor: primaryColor,
       canvasColor: canvasColor,
@@ -286,6 +286,24 @@ class MacosThemeData with Diagnosticable {
       iconTheme: iconTheme,
       macosPopupButtonTheme: macosPopupButtonTheme,
     );
+
+    final customizedData = defaultData.copyWith(
+      brightness: _brightness,
+      primaryColor: primaryColor,
+      canvasColor: canvasColor,
+      typography: typography,
+      pushButtonTheme: pushButtonTheme,
+      dividerColor: dividerColor,
+      helpButtonTheme: helpButtonTheme,
+      tooltipTheme: tooltipTheme,
+      visualDensity: visualDensity,
+      scrollbarTheme: scrollbarTheme,
+      macosIconButtonTheme: macosIconButtonThemeData,
+      iconTheme: iconTheme,
+      macosPopupButtonTheme: macosPopupButtonTheme,
+    );
+
+    return defaultData.merge(customizedData);
   }
 
   /// Create a [MacosThemeData] given a set of exact values. All the values must
@@ -423,16 +441,38 @@ class MacosThemeData with Diagnosticable {
       primaryColor: primaryColor ?? this.primaryColor,
       canvasColor: canvasColor ?? this.canvasColor,
       dividerColor: dividerColor ?? this.dividerColor,
-      typography: typography ?? this.typography,
-      pushButtonTheme: pushButtonTheme ?? this.pushButtonTheme,
-      helpButtonTheme: helpButtonTheme ?? this.helpButtonTheme,
-      tooltipTheme: tooltipTheme ?? this.tooltipTheme,
+      typography: this.typography.merge(typography),
+      pushButtonTheme: this.pushButtonTheme.merge(pushButtonTheme),
+      helpButtonTheme: this.helpButtonTheme.merge(helpButtonTheme),
+      tooltipTheme: this.tooltipTheme.merge(tooltipTheme),
       visualDensity: visualDensity ?? this.visualDensity,
-      scrollbarTheme: scrollbarTheme ?? this.scrollbarTheme,
-      macosIconButtonTheme: macosIconButtonTheme ?? this.macosIconButtonTheme,
-      iconTheme: iconTheme ?? this.iconTheme,
+      scrollbarTheme: this.scrollbarTheme.merge(scrollbarTheme),
+      macosIconButtonTheme:
+          this.macosIconButtonTheme.merge(macosIconButtonTheme),
+      iconTheme: this.iconTheme.merge(iconTheme),
       macosPopupButtonTheme:
-          macosPopupButtonTheme ?? this.macosPopupButtonTheme,
+          this.macosPopupButtonTheme.merge(macosPopupButtonTheme),
+    );
+  }
+
+  MacosThemeData merge(MacosThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      brightness: other.brightness,
+      primaryColor: other.primaryColor,
+      canvasColor: other.canvasColor,
+      dividerColor: other.dividerColor,
+      typography: typography.merge(other.typography),
+      pushButtonTheme: pushButtonTheme.merge(other.pushButtonTheme),
+      helpButtonTheme: helpButtonTheme.merge(other.helpButtonTheme),
+      tooltipTheme: tooltipTheme.merge(other.tooltipTheme),
+      visualDensity: other.visualDensity,
+      scrollbarTheme: scrollbarTheme.merge(other.scrollbarTheme),
+      macosIconButtonTheme:
+          macosIconButtonTheme.merge(other.macosIconButtonTheme),
+      iconTheme: iconTheme.merge(other.iconTheme),
+      macosPopupButtonTheme:
+          macosPopupButtonTheme.merge(other.macosPopupButtonTheme),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 0.12.2
+version: 0.12.2+1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
Adds missing `merge()` methods to `MacosThemeData` and widget-specific `ThemeData` classes, making it possible to use them properly with any number of user-provided custom properties. This issue was previously discussed in #182 and #183, where if the user didn't explicitly set all properties for a `ThemeData` the app crashed with a null-check CastError.

Now, customizing a couple of theme properties is possible. Example:

```dart
darkTheme: MacosThemeData.dark().copyWith(
  canvasColor: MacosColors.selectedTextBackgroundColor,
  pushButtonTheme: const PushButtonThemeData(
    color: MacosColors.applePurple,
  ),
  tooltipTheme: const TooltipThemeData(
    height: 100.0,
  ),
  macosIconButtonTheme: const MacosIconButtonThemeData(
    backgroundColor: MacosColors.appleBlue,
  ),
  macosPopupButtonTheme: const MacosPopupButtonThemeData(
    highlightColor: MacosColors.appleGreen,
  )),
),
```

Also fixed some minor errors/typos in the widget `ThemeData` classes.

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->