### PR TITLE
`MacosColorWell` docfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.0+1]
+* Minor documentation fix for [MacosColorWell]
+
 ## [1.0.0]
 * First stable release 🎉
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.0+1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/selectors/color_well.dart
+++ b/lib/src/selectors/color_well.dart
@@ -46,6 +46,7 @@ enum ColorPickerMode {
 /// {@endtemplate}
 typedef OnColorSelected = void Function(Color color);
 
+/// {@template macosColorWell}
 /// A control that displays a color value and lets the user change that color
 /// value.
 ///
@@ -53,7 +54,9 @@ typedef OnColorSelected = void Function(Color color);
 /// which is an `NSColorPanel` from the Swift Cocoa library.
 ///
 /// Use a [MacosColorWell] when you want the user to be able to select a color.
+/// {@endtemplate}
 class MacosColorWell extends StatefulWidget {
+  /// {@macro macosColorWell}
   const MacosColorWell({
     Key? key,
     required this.onColorSelected,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.0.0
+version: 1.0.0+1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
This PR fixes a minor documentation issue for `MacosColorWell`

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->