### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.1]
+* Improvements to the graphical `MacosTimePicker`
+  * Better color gradient on the border
+  * Better inner shadow
+  * Minor size adjustments
+  * API improvements
+
 ## [1.0.0+1]
 * Minor documentation fix for [MacosColorWell]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Better inner shadow
   * Minor size adjustments
   * API improvements
+* Throw an exception if `MacosColorWell` is clicked on a non-macOS platform
 
 ## [1.0.0+1]
 * Minor documentation fix for [MacosColorWell]

--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ There are three styles of `MacosDatePickers`:
 
 ## MacosTimePicker
 
-<img src="https://imgur.com/UKMDnSF.png" width="50%"/>
+<img src="https://imgur.com/RtPbRo2.png" width="50%"/>
 
 Lets the user choose a time.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0+1"
+    version: "1.0.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/selectors/color_well.dart
+++ b/lib/src/selectors/color_well.dart
@@ -46,6 +46,7 @@ enum ColorPickerMode {
 /// {@endtemplate}
 typedef OnColorSelected = void Function(Color color);
 
+/// {@template macosColorWell}
 /// A control that displays a color value and lets the user change that color
 /// value.
 ///
@@ -53,7 +54,9 @@ typedef OnColorSelected = void Function(Color color);
 /// which is an `NSColorPanel` from the Swift Cocoa library.
 ///
 /// Use a [MacosColorWell] when you want the user to be able to select a color.
+/// {@endtemplate}
 class MacosColorWell extends StatefulWidget {
+  /// {@macro macosColorWell}
   const MacosColorWell({
     Key? key,
     required this.onColorSelected,

--- a/lib/src/selectors/color_well.dart
+++ b/lib/src/selectors/color_well.dart
@@ -114,7 +114,7 @@ class _MacosColorWellState extends State<MacosColorWell> {
           await _methodChannel.invokeMethod('color_panel', {
             'mode': '${widget.defaultMode}',
           });
-        } on MissingPluginException catch (e) {
+        } on MissingPluginException {
           throw MissingPluginException(
             'Cannot open NSColorPanel on platforms other than macOS.',
           );

--- a/lib/src/selectors/color_well.dart
+++ b/lib/src/selectors/color_well.dart
@@ -114,8 +114,12 @@ class _MacosColorWellState extends State<MacosColorWell> {
           await _methodChannel.invokeMethod('color_panel', {
             'mode': '${widget.defaultMode}',
           });
+        } on MissingPluginException catch (e) {
+          throw MissingPluginException(
+            'Cannot open NSColorPanel on platforms other than macOS.',
+          );
         } catch (e) {
-          debugPrint('$e');
+          debugPrint('Failed to open color panel: $e');
         }
       },
       child: SizedBox(

--- a/lib/src/selectors/graphical_time_picker_painter.dart
+++ b/lib/src/selectors/graphical_time_picker_painter.dart
@@ -1,30 +1,29 @@
 import 'dart:math';
 
+import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
-import 'package:macos_ui/src/theme/macos_colors.dart';
 
+/// {@template graphicalTimePickerPainter}
+/// A [CustomPainter] that recreates the native macOS graphical time picker.
+/// {@endtemplate}
 class GraphicalTimePickerPainter extends CustomPainter {
   GraphicalTimePickerPainter({
     required this.clockHeight,
     required this.time,
     required this.dayPeriod,
-    required this.backgroundColor,
-    required this.hourHandColor,
-    required this.minuteHandColor,
-    required this.secondHandColor,
-    required this.dayPeriodTextColor,
-    required this.outerBorderColor,
+    required this.theme,
   });
 
+  /// The height of the clock.
   final double clockHeight;
+
+  /// The time to display.
   final DateTime time;
+
+  /// The day period to display (AM/PM).
   final String dayPeriod;
-  final Color backgroundColor;
-  final Color hourHandColor;
-  final Color minuteHandColor;
-  final Color secondHandColor;
-  final Color dayPeriodTextColor;
-  final Color outerBorderColor;
+
+  final MacosTimePickerThemeData theme;
 
   static const double handPinHoleSize = 3.0;
   static const double strokeWidth = 3.0;
@@ -32,10 +31,7 @@ class GraphicalTimePickerPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final double scaleFactor = size.shortestSide / clockHeight;
-    _paintClockBorder(canvas, size);
-    _paintBackgroundColor(canvas, size);
-    _paintInnerShadow(canvas, size);
-    //_paintLightInnerShadow(canvas, size);
+    _paintBaseClock(canvas, size);
     _paintDayPeriod(canvas, size);
     _paintHours(canvas, size, scaleFactor);
     _paintPinHole(canvas, size);
@@ -45,6 +41,119 @@ class GraphicalTimePickerPainter extends CustomPainter {
   @override
   bool shouldRepaint(GraphicalTimePickerPainter oldDelegate) {
     return true;
+  }
+
+  Offset _getHandOffset(double percentage, double length) {
+    final radians = 2 * pi * percentage;
+    final angle = -pi / 2.0 + radians;
+
+    return Offset(length * cos(angle), length * sin(angle));
+  }
+
+  /// Paints the clock border, inner shadow, and background
+  void _paintBaseClock(Canvas canvas, Size size) {
+    //---Border---//
+    const borderWidth = 5.0;
+    final center = size.center(Offset.zero);
+    final radius1 = size.shortestSide / 2.0;
+    final radius2 = radius1 - borderWidth;
+    final rect1 = Rect.fromCircle(center: center, radius: radius1);
+    final rect2 = Rect.fromCircle(center: center, radius: radius2);
+    final shader = LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        theme.clockViewBorderColor!,
+        Color.alphaBlend(
+          const MacosColor(0xFF767574),
+          theme.clockViewBorderColor!,
+        ),
+      ],
+    ).createShader(rect1);
+    // Draw the border
+    canvas.drawOval(rect1, Paint()..shader = shader);
+
+    //---Background---//
+    canvas.drawOval(rect2, Paint()..color = theme.clockViewBackgroundColor!);
+
+    //---Inner shadow---//
+    const blurRadius = 3.0;
+    final shadowPainter = Paint()
+      ..maskFilter = const MaskFilter.blur(
+        BlurStyle.normal,
+        blurRadius,
+      )
+      ..color = MacosColors.black;
+    final path = Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect(
+        const EdgeInsets.all(blurRadius)
+            .copyWith(bottom: -rect2.height / 2)
+            .inflateRect(rect2),
+      )
+      ..addArc(
+        const EdgeInsets.symmetric(horizontal: blurRadius).inflateRect(rect2),
+        pi,
+        pi,
+      );
+    canvas.clipPath(Path()..addOval(rect2));
+    canvas.drawPath(path, shadowPainter);
+    canvas.drawPath(path, shadowPainter);
+  }
+
+  void _paintDayPeriod(Canvas canvas, Size size) {
+    TextStyle style = TextStyle(
+      color: theme.dayPeriodTextColor,
+      fontSize: 13.0,
+    );
+    TextSpan span = TextSpan(
+      style: style,
+      text: dayPeriod,
+    );
+    TextPainter periodPainter = TextPainter(
+      text: span,
+      textAlign: TextAlign.center,
+      textDirection: TextDirection.ltr,
+    );
+    periodPainter.layout();
+    periodPainter.paint(
+      canvas,
+      size.center(
+        const Offset(0.0, 20.0) - periodPainter.size.center(Offset.zero),
+      ),
+    );
+  }
+
+  void _paintHours(
+    Canvas canvas,
+    Size size,
+    double scaleFactor,
+  ) {
+    TextStyle style = const TextStyle(
+      color: MacosColors.black,
+      fontWeight: FontWeight.w300,
+      fontSize: 13.0,
+    );
+    double distanceFromBorder = 16.0;
+
+    double radius = size.shortestSide / 2;
+    double longHandLength = radius - (distanceFromBorder * scaleFactor);
+
+    for (var hour = 1; hour <= 12; hour++) {
+      double angle = (hour * pi / 6) - pi / 2;
+      Offset offset = Offset(
+        longHandLength * cos(angle),
+        longHandLength * sin(angle),
+      );
+      TextSpan span = TextSpan(style: style, text: hour.toString());
+      TextPainter tp = TextPainter(
+        text: span,
+        textAlign: TextAlign.center,
+        textDirection: TextDirection.ltr,
+      );
+      tp.layout();
+      tp.paint(canvas, size.center(offset - tp.size.center(Offset.zero)));
+    }
   }
 
   void _paintPinHole(Canvas canvas, Size size) {
@@ -60,86 +169,12 @@ class GraphicalTimePickerPainter extends CustomPainter {
     );
   }
 
-  Offset _getHandOffset(double percentage, double length) {
-    final radians = 2 * pi * percentage;
-    final angle = -pi / 2.0 + radians;
-
-    return Offset(length * cos(angle), length * sin(angle));
-  }
-
-  void _paintClockBorder(Canvas canvas, Size size) {
-    final clockBorderPainter = Paint()
-      ..color = outerBorderColor
-      ..strokeWidth = 12.0
-      ..isAntiAlias = true
-      ..shader = LinearGradient(
-        begin: Alignment.centerLeft,
-        end: Alignment.bottomLeft,
-        colors: [
-          outerBorderColor,
-          const MacosColor(0xFF767574),
-        ],
-      ).createShader(
-        Rect.fromCircle(
-          center: size.center(Offset.zero),
-          radius: clockHeight / 2,
-        ),
-      )
-      ..style = PaintingStyle.stroke;
-
-    canvas.drawCircle(
-      size.center(Offset.zero),
-      size.shortestSide / 2.0,
-      clockBorderPainter,
-    );
-  }
-
-  void _paintBackgroundColor(Canvas canvas, Size size) {
-    final backgroundPaint = Paint()
-      ..color = backgroundColor
-      ..style = PaintingStyle.fill;
-
-    canvas.drawCircle(
-      size.center(Offset.zero),
-      clockHeight / 2,
-      backgroundPaint,
-    );
-  }
-
-  void _paintInnerShadow(Canvas canvas, Size size) {
-    final innerShadowPainter = Paint()
-      ..strokeWidth = 2.0
-      ..isAntiAlias = true
-      ..shader = const LinearGradient(
-        begin: Alignment.centerLeft,
-        end: Alignment.bottomLeft,
-        stops: [0.0, 0.5],
-        colors: [
-          MacosColor(0xFFA3A4A5),
-          MacosColors.white,
-        ],
-      ).createShader(
-        Rect.fromCircle(
-          center: size.center(Offset.zero),
-          radius: clockHeight / 2,
-        ),
-      )
-      ..maskFilter = const MaskFilter.blur(BlurStyle.inner, 1.0)
-      ..style = PaintingStyle.stroke;
-
-    canvas.drawCircle(
-      size.center(Offset.zero),
-      size.shortestSide / 2.0,
-      innerShadowPainter,
-    );
-  }
-
   void _paintClockHands(Canvas canvas, Size size, double scaleFactor) {
     double r = size.shortestSide / 2;
     double p = 0.0;
-    double hourHandLength = r - (p + 22.0) * scaleFactor;
-    double minuteHandLength = r - (p * scaleFactor) - 3.0;
-    double secondHandLength = r - (p * scaleFactor) - 2.0;
+    double hourHandLength = r - (p + 26.0) * scaleFactor;
+    double minuteHandLength = r - (p * scaleFactor) - 9.5;
+    double secondHandLength = r - (p * scaleFactor) - 8.0;
 
     final handPaint = Paint()
       ..style = PaintingStyle.stroke
@@ -154,14 +189,14 @@ class GraphicalTimePickerPainter extends CustomPainter {
     canvas.drawLine(
       size.center(_getHandOffset(hour, handPinHoleSize * scaleFactor)),
       size.center(_getHandOffset(hour, hourHandLength)),
-      handPaint..color = hourHandColor,
+      handPaint..color = theme.hourHandColor!,
     );
 
     // Draw minute hand
     canvas.drawLine(
       size.center(_getHandOffset(minutes, handPinHoleSize * scaleFactor)),
       size.center(_getHandOffset(minutes, minuteHandLength)),
-      handPaint..color = minuteHandColor,
+      handPaint..color = theme.minuteHandColor!,
     );
 
     // Draw second hand
@@ -169,13 +204,13 @@ class GraphicalTimePickerPainter extends CustomPainter {
       size.center(_getHandOffset(seconds, handPinHoleSize * scaleFactor)),
       size.center(_getHandOffset(seconds, secondHandLength)),
       handPaint
-        ..color = secondHandColor
+        ..color = theme.secondHandColor!
         ..strokeWidth = 1.0
         ..strokeCap = StrokeCap.square,
     );
 
     final secondHandPinPaint = Paint()
-      ..color = secondHandColor
+      ..color = theme.secondHandColor!
       ..isAntiAlias = true
       ..style = PaintingStyle.fill;
 
@@ -191,62 +226,9 @@ class GraphicalTimePickerPainter extends CustomPainter {
       size.center(Offset.zero),
       size.center(_getHandOffset(seconds, -6.3)),
       handPaint
-        ..color = secondHandColor
+        ..color = theme.secondHandColor!
         ..strokeWidth = 1.0
         ..strokeCap = StrokeCap.square,
     );
-  }
-
-  void _paintDayPeriod(Canvas canvas, Size size) {
-    TextStyle style = TextStyle(
-      color: dayPeriodTextColor,
-      fontSize: 13.0,
-    );
-    TextSpan span = TextSpan(
-      style: style,
-      text: dayPeriod,
-    );
-    TextPainter tp = TextPainter(
-      text: span,
-      textAlign: TextAlign.center,
-      textDirection: TextDirection.ltr,
-    );
-    tp.layout();
-    tp.paint(
-      canvas,
-      size.center(const Offset(0.0, 20.0) - tp.size.center(Offset.zero)),
-    );
-  }
-
-  void _paintHours(
-    Canvas canvas,
-    Size size,
-    double scaleFactor,
-  ) {
-    TextStyle style = const TextStyle(
-      color: MacosColors.black,
-      fontWeight: FontWeight.w400,
-      fontSize: 13.0,
-    );
-    double distanceFromBorder = 10.0;
-
-    double r = size.shortestSide / 2;
-    double longHandLength = r - (distanceFromBorder * scaleFactor);
-
-    for (var h = 1; h <= 12; h++) {
-      double angle = (h * pi / 6) - pi / 2;
-      Offset offset = Offset(
-        longHandLength * cos(angle),
-        longHandLength * sin(angle),
-      );
-      TextSpan span = TextSpan(style: style, text: h.toString());
-      TextPainter tp = TextPainter(
-        text: span,
-        textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
-      );
-      tp.layout();
-      tp.paint(canvas, size.center(offset - tp.size.center(Offset.zero)));
-    }
   }
 }

--- a/lib/src/selectors/graphical_time_picker_painter.dart
+++ b/lib/src/selectors/graphical_time_picker_painter.dart
@@ -7,6 +7,7 @@ import 'package:macos_ui/src/library.dart';
 /// A [CustomPainter] that recreates the native macOS graphical time picker.
 /// {@endtemplate}
 class GraphicalTimePickerPainter extends CustomPainter {
+  /// {@macro graphicalTimePickerPainter}
   GraphicalTimePickerPainter({
     required this.clockHeight,
     required this.time,
@@ -23,6 +24,7 @@ class GraphicalTimePickerPainter extends CustomPainter {
   /// The day period to display (AM/PM).
   final String dayPeriod;
 
+  /// The theme to use.
   final MacosTimePickerThemeData theme;
 
   static const double handPinHoleSize = 3.0;

--- a/lib/src/selectors/time_picker.dart
+++ b/lib/src/selectors/time_picker.dart
@@ -8,8 +8,13 @@ import 'package:macos_ui/src/selectors/keyboard_shortcut_runner.dart';
 
 /// Defines the possibles [MacosTimePicker] styles.
 enum TimePickerStyle {
+  /// A text-only variant of the time picker.
   textual,
+
+  /// A graphical variant of the time picker.
   graphical,
+
+  /// Combines both the [textual] and [graphical] styles.
   combined,
 }
 

--- a/lib/src/selectors/time_picker.dart
+++ b/lib/src/selectors/time_picker.dart
@@ -322,8 +322,8 @@ class _MacosTimePickerState extends State<MacosTimePicker> {
   }
 
   Widget _buildGraphicalTimePicker(MacosTimePickerThemeData timePickerTheme) {
-    const _clockHeight = 101.0;
-    const _clockWidth = 100.0;
+    const _clockHeight = 116.0;
+    const _clockWidth = 115.0;
     return SizedBox(
       height: _clockHeight,
       width: _clockWidth,
@@ -339,12 +339,7 @@ class _MacosTimePickerState extends State<MacosTimePicker> {
             DateTime.now().second,
           ),
           dayPeriod: _selectedPeriod == DayPeriod.am ? 'AM' : 'PM',
-          backgroundColor: timePickerTheme.clockViewBackgroundColor!,
-          hourHandColor: timePickerTheme.hourHandColor!,
-          minuteHandColor: timePickerTheme.minuteHandColor!,
-          secondHandColor: timePickerTheme.secondHandColor!,
-          dayPeriodTextColor: timePickerTheme.dayPeriodTextColor!,
-          outerBorderColor: timePickerTheme.clockViewBorderColor!,
+          theme: timePickerTheme,
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.0.0+1
+version: 1.0.1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/test/selectors/date_picker_test.dart
+++ b/test/selectors/date_picker_test.dart
@@ -5,7 +5,7 @@ import 'package:macos_ui/macos_ui.dart';
 
 void main() {
   group('MacosDatePicker tests', () {
-    testWidgets('textual MacosDatePicker renders the expected date',
+    testWidgets('Textual MacosDatePicker renders the expected date',
         (tester) async {
       final today = DateTime.now();
       await tester.pumpWidget(

--- a/test/selectors/date_picker_test.dart
+++ b/test/selectors/date_picker_test.dart
@@ -5,7 +5,8 @@ import 'package:macos_ui/macos_ui.dart';
 
 void main() {
   group('MacosDatePicker tests', () {
-    testWidgets('textual MacosDatePicker renders the expected date', (tester) async {
+    testWidgets('textual MacosDatePicker renders the expected date',
+        (tester) async {
       final today = DateTime.now();
       await tester.pumpWidget(
         MacosApp(

--- a/test/selectors/date_picker_test.dart
+++ b/test/selectors/date_picker_test.dart
@@ -5,7 +5,7 @@ import 'package:macos_ui/macos_ui.dart';
 
 void main() {
   group('MacosDatePicker tests', () {
-    testWidgets('MacosDatePicker renders the expected date', (tester) async {
+    testWidgets('textual MacosDatePicker renders the expected date', (tester) async {
       final today = DateTime.now();
       await tester.pumpWidget(
         MacosApp(
@@ -17,6 +17,7 @@ void main() {
                     return Center(
                       child: MacosDatePicker(
                         onDateChanged: (date) {},
+                        style: DatePickerStyle.textual,
                       ),
                     );
                   },


### PR DESCRIPTION
### Changes
* Improvements to the graphical `MacosTimePicker`
  * Better color gradient on the border
  * Better inner shadow
  * Minor size adjustments
  * API improvements
* Throw an exception if `MacosColorWell` is clicked on a non-macOS platform

![Screen Shot 2022-05-05 at 10 38 30 AM](https://user-images.githubusercontent.com/4250470/166947961-b8bb5832-e38f-4a35-a0cd-0a1b12298d07.png)

Closes #221 and #218

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->