### PR TITLE
Improve `MacosTooltip`, add tooltip property to toolbar items, and implement `ToolbarDivider` (closes #231, #232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.2.0]
+* Improved styling for `MacosTooltip`:
+  * Better color and shadows.
+  * Displays left-aligned, below the mouse cursor.
+* New widget: `ToolBarDivider` that can be used as a divider (vertical/horizontal line) in the `ToolBar` [#231](https://github.com/GroovinChip/macos_ui/issues/231).
+* All toolbar widgets can now receive a `tooltipMessage` property to display a `MacosTooltip` when user hovers over them [#232](https://github.com/GroovinChip/macos_ui/issues/232).
+
 ## [1.1.0]
 * New functionality for `MacosSearchField`
   * Shows a list of search results in an overlay below the field

--- a/README.md
+++ b/README.md
@@ -662,9 +662,11 @@ Tooltips succinctly describe how to use controls without shifting people’s foc
 Help tags appear when the user positions the pointer over a control for a few seconds. A tooltip remains visible for 
 10 seconds, or until the pointer moves away from the control.
 
-![Tooltip Example](https://developer.apple.com/design/human-interface-guidelines/macos/images/help_Tooltip.png)
+| Dark Theme                                 | Light Theme                                |
+| ------------------------------------------ | ------------------------------------------ |
+| <img src="https://imgur.com/0qLFqdK.jpg"/> | <img src="https://imgur.com/Y3PLqBo.jpg"/> |
 
-To create a tooltip, wrap any widget on a `Tooltip`:
+To create a tooltip, wrap any widget on a `MacosTooltip`:
 
 ```dart
 MacosTooltip(
@@ -673,8 +675,8 @@ MacosTooltip(
 ),
 ```
 
-You can customize the tooltip the way you want using its `style` property. A tooltip automatically adapts to its 
-environment, responding to touch and pointer events.
+You can customize the tooltip the way you want by customizing the theme's `TooltipTheme`. A tooltip automatically adapts to its 
+environment, responding to touch and pointer events. To use a tooltip with a toolbar item, provide it with a `tooltipMessage` property.
 
 # Indicators
 

--- a/example/lib/pages/toolbar_page.dart
+++ b/example/lib/pages/toolbar_page.dart
@@ -24,6 +24,7 @@ class _ToolbarPageState extends State<ToolbarPage> {
             onPressed: () => debugPrint("New Folder..."),
             label: "New Folder",
             showLabel: true,
+            tooltipMessage: "This is a beautiful tooltip",
           ),
           ToolBarIconButton(
             icon: const MacosIcon(
@@ -32,6 +33,7 @@ class _ToolbarPageState extends State<ToolbarPage> {
             onPressed: () => debugPrint("Add..."),
             label: "Add",
             showLabel: true,
+            tooltipMessage: "This is a beautiful tooltip",
           ),
           const ToolBarSpacer(),
           ToolBarIconButton(
@@ -41,6 +43,7 @@ class _ToolbarPageState extends State<ToolbarPage> {
             ),
             onPressed: () => debugPrint("pressed"),
             showLabel: false,
+            tooltipMessage: "This is a beautiful tooltip",
           ),
           const ToolBarIconButton(
             label: "Change View",
@@ -48,6 +51,7 @@ class _ToolbarPageState extends State<ToolbarPage> {
               CupertinoIcons.list_bullet,
             ),
             showLabel: false,
+            tooltipMessage: "This is a beautiful tooltip",
           ),
           ToolBarPullDownButton(
             label: "Actions",

--- a/example/lib/pages/toolbar_page.dart
+++ b/example/lib/pages/toolbar_page.dart
@@ -93,6 +93,7 @@ class _ToolbarPageState extends State<ToolbarPage> {
               ),
             ],
           ),
+          const ToolBarDivider(),
           ToolBarIconButton(
             label: "Table",
             icon: const MacosIcon(

--- a/example/lib/pages/toolbar_page.dart
+++ b/example/lib/pages/toolbar_page.dart
@@ -33,7 +33,7 @@ class _ToolbarPageState extends State<ToolbarPage> {
             onPressed: () => debugPrint("Add..."),
             label: "Add",
             showLabel: true,
-            tooltipMessage: "This is a beautiful tooltip",
+            tooltipMessage: "This is another beautiful tooltip",
           ),
           const ToolBarSpacer(),
           ToolBarIconButton(
@@ -43,7 +43,6 @@ class _ToolbarPageState extends State<ToolbarPage> {
             ),
             onPressed: () => debugPrint("pressed"),
             showLabel: false,
-            tooltipMessage: "This is a beautiful tooltip",
           ),
           const ToolBarIconButton(
             label: "Change View",
@@ -51,11 +50,11 @@ class _ToolbarPageState extends State<ToolbarPage> {
               CupertinoIcons.list_bullet,
             ),
             showLabel: false,
-            tooltipMessage: "This is a beautiful tooltip",
           ),
           ToolBarPullDownButton(
             label: "Actions",
             icon: CupertinoIcons.ellipsis_circle,
+            tooltipMessage: "Perform tasks with the selected items",
             items: [
               MacosPulldownMenuItem(
                 label: "New Folder",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   matcher:
     dependency: transitive
     description:

--- a/lib/macos_ui.dart
+++ b/lib/macos_ui.dart
@@ -42,6 +42,7 @@ export 'src/layout/sidebar_item.dart';
 export 'src/layout/title_bar.dart';
 export 'src/layout/toolbar/custom_toolbar_item.dart';
 export 'src/layout/toolbar/toolbar.dart';
+export 'src/layout/toolbar/toolbar_divider.dart';
 export 'src/layout/toolbar/toolbar_overflow_menu.dart';
 export 'src/layout/toolbar/toolbar_overflow_menu_item.dart';
 export 'src/layout/toolbar/toolbar_popup.dart';

--- a/lib/src/buttons/toolbar/toolbar_icon_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_icon_button.dart
@@ -45,6 +45,8 @@ class ToolBarIconButton extends ToolbarItem {
   /// "image button" toolbar item.
   final bool showLabel;
 
+  /// An optional message to appear in a tooltip when user hovers over the
+  /// button.
   final String? tooltipMessage;
 
   @override

--- a/lib/src/buttons/toolbar/toolbar_icon_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_icon_button.dart
@@ -20,6 +20,7 @@ class ToolBarIconButton extends ToolbarItem {
     required this.icon,
     this.onPressed,
     required this.showLabel,
+    this.tooltipMessage,
   }) : super(key: key);
 
   /// The label that describes this button's action.
@@ -44,11 +45,13 @@ class ToolBarIconButton extends ToolbarItem {
   /// "image button" toolbar item.
   final bool showLabel;
 
+  final String? tooltipMessage;
+
   @override
   Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
     final brightness = MacosTheme.of(context).brightness;
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
-      final Widget iconButton = MacosIconButton(
+      Widget _iconButton = MacosIconButton(
         disabledColor: Colors.transparent,
         icon: MacosIconTheme(
           data: MacosTheme.of(context).iconTheme.copyWith(
@@ -71,11 +74,11 @@ class ToolBarIconButton extends ToolbarItem {
       );
 
       if (showLabel) {
-        return Padding(
+        _iconButton = Padding(
           padding: const EdgeInsets.fromLTRB(6.0, 6.0, 6.0, 0.0),
           child: Column(
             children: [
-              iconButton,
+              _iconButton,
               Padding(
                 padding: const EdgeInsets.only(top: 4.0),
                 child: Text(
@@ -89,9 +92,15 @@ class ToolBarIconButton extends ToolbarItem {
             ],
           ),
         );
-      } else {
-        return iconButton;
       }
+
+      if (tooltipMessage != null) {
+        _iconButton = MacosTooltip(
+          message: tooltipMessage!,
+          child: _iconButton,
+        );
+      }
+      return _iconButton;
     } else {
       return ToolbarOverflowMenuItem(
         label: label,

--- a/lib/src/buttons/toolbar/toolbar_pulldown_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_pulldown_button.dart
@@ -16,6 +16,7 @@ class ToolBarPullDownButton extends ToolbarItem {
     required this.label,
     required this.icon,
     required this.items,
+    this.tooltipMessage,
   }) : super(key: key);
 
   /// The label that describes this button's action.
@@ -43,12 +44,16 @@ class ToolBarPullDownButton extends ToolbarItem {
   /// content.
   final List<MacosPulldownMenuEntry>? items;
 
+  /// An optional message to appear in a tooltip when user hovers over the
+  /// pull-down button.
+  final String? tooltipMessage;
+
   @override
   Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
     final brightness = MacosTheme.of(context).brightness;
 
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
-      return Padding(
+      Widget _pulldownButton = Padding(
         padding: const EdgeInsets.symmetric(vertical: 6.0),
         child: MacosPulldownButtonTheme(
           data: MacosPulldownButtonTheme.of(context).copyWith(
@@ -63,6 +68,14 @@ class ToolBarPullDownButton extends ToolbarItem {
           ),
         ),
       );
+
+      if (tooltipMessage != null) {
+        _pulldownButton = MacosTooltip(
+          message: tooltipMessage!,
+          child: _pulldownButton,
+        );
+      }
+      return _pulldownButton;
     } else {
       // We should show a submenu for the pulldown button items.
       final subMenuKey = GlobalKey<ToolbarPopupState>();

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -331,7 +331,7 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
     return positionDependentBox(
       size: size,
       childSize: childSize,
-      target: target,
+      target: Offset(target.dx + childSize.width / 2, target.dy),
       verticalOffset: verticalOffset,
       preferBelow: preferBelow,
     );

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:macos_ui/macos_ui.dart';
@@ -67,12 +66,8 @@ class MacosTooltip extends StatefulWidget {
 
 class _MacosTooltipState extends State<MacosTooltip>
     with SingleTickerProviderStateMixin {
-  static const double _defaultVerticalOffset = 24.0;
-  static const bool _defaultPreferBelow = false;
-  static const EdgeInsetsGeometry _defaultMargin = EdgeInsets.all(0.0);
   static const Duration _fadeInDuration = Duration(milliseconds: 150);
   static const Duration _fadeOutDuration = Duration(milliseconds: 75);
-  static const Duration _defaultWaitDuration = Duration.zero;
 
   late double height;
   late EdgeInsetsGeometry padding;
@@ -107,51 +102,6 @@ class _MacosTooltipState extends State<MacosTooltip>
     // Listen to global pointer events so that we can hide a tooltip immediately
     // if some other control is clicked on.
     GestureBinding.instance!.pointerRouter.addGlobalRoute(_handlePointerEvent);
-  }
-
-  Duration _getDefaultShowDuration() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return const Duration(seconds: 10);
-      default:
-        return const Duration(milliseconds: 1500);
-    }
-  }
-
-  // https://material.io/components/tooltips#specs
-  double _getDefaultTooltipHeight() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return 24.0;
-      default:
-        return 32.0;
-    }
-  }
-
-  EdgeInsets _getDefaultPadding() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return const EdgeInsets.symmetric(horizontal: 8.0);
-      default:
-        return const EdgeInsets.symmetric(horizontal: 16.0);
-    }
-  }
-
-  double _getDefaultFontSize() {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.macOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        return 10.0;
-      default:
-        return 14.0;
-    }
   }
 
   // Forces a rebuild if a mouse has been added or removed.
@@ -312,31 +262,18 @@ class _MacosTooltipState extends State<MacosTooltip>
   Widget build(BuildContext context) {
     assert(debugCheckHasMacosTheme(context));
     assert(Overlay.of(context, debugRequiredFor: widget) != null);
-    final MacosThemeData theme = MacosTheme.of(context);
-    final tooltipTheme = theme.tooltipTheme.copyWith();
-    final TextStyle? defaultTextStyle;
-    if (theme.brightness == Brightness.dark) {
-      defaultTextStyle = theme.typography.body.copyWith(
-        color: CupertinoColors.black,
-        fontSize: _getDefaultFontSize(),
-      );
-    } else {
-      defaultTextStyle = theme.typography.body.copyWith(
-        color: CupertinoColors.white,
-        fontSize: _getDefaultFontSize(),
-      );
-    }
+    final tooltipTheme = TooltipTheme.of(context);
 
-    height = tooltipTheme.height ?? _getDefaultTooltipHeight();
-    padding = tooltipTheme.padding ?? _getDefaultPadding();
-    margin = tooltipTheme.margin ?? _defaultMargin;
-    verticalOffset = tooltipTheme.verticalOffset ?? _defaultVerticalOffset;
-    preferBelow = tooltipTheme.preferBelow ?? _defaultPreferBelow;
+    height = tooltipTheme.height!;
+    padding = tooltipTheme.padding!;
+    margin = tooltipTheme.margin!;
+    verticalOffset = tooltipTheme.verticalOffset!;
+    preferBelow = tooltipTheme.preferBelow!;
     excludeFromSemantics = widget.excludeFromSemantics;
     decoration = tooltipTheme.decoration!;
-    textStyle = tooltipTheme.textStyle ?? defaultTextStyle;
-    waitDuration = tooltipTheme.waitDuration ?? _defaultWaitDuration;
-    showDuration = tooltipTheme.showDuration ?? _getDefaultShowDuration();
+    textStyle = tooltipTheme.textStyle!;
+    waitDuration = tooltipTheme.waitDuration!;
+    showDuration = tooltipTheme.showDuration!;
 
     Widget result = GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -441,7 +378,6 @@ class _TooltipOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print(decoration);
     return Positioned.fill(
       child: IgnorePointer(
         child: CustomSingleChildLayout(

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -315,24 +315,15 @@ class _MacosTooltipState extends State<MacosTooltip>
     final MacosThemeData theme = MacosTheme.of(context);
     final tooltipTheme = theme.tooltipTheme.copyWith();
     final TextStyle? defaultTextStyle;
-    final BoxDecoration defaultDecoration;
     if (theme.brightness == Brightness.dark) {
       defaultTextStyle = theme.typography.body.copyWith(
         color: CupertinoColors.black,
         fontSize: _getDefaultFontSize(),
       );
-      defaultDecoration = BoxDecoration(
-        color: CupertinoColors.white.withOpacity(0.9),
-        borderRadius: const BorderRadius.all(Radius.circular(4)),
-      );
     } else {
       defaultTextStyle = theme.typography.body.copyWith(
         color: CupertinoColors.white,
         fontSize: _getDefaultFontSize(),
-      );
-      defaultDecoration = BoxDecoration(
-        color: CupertinoColors.black.withOpacity(0.9),
-        borderRadius: const BorderRadius.all(Radius.circular(4)),
       );
     }
 
@@ -342,7 +333,7 @@ class _MacosTooltipState extends State<MacosTooltip>
     verticalOffset = tooltipTheme.verticalOffset ?? _defaultVerticalOffset;
     preferBelow = tooltipTheme.preferBelow ?? _defaultPreferBelow;
     excludeFromSemantics = widget.excludeFromSemantics;
-    decoration = tooltipTheme.decoration ?? defaultDecoration;
+    decoration = tooltipTheme.decoration!;
     textStyle = tooltipTheme.textStyle ?? defaultTextStyle;
     waitDuration = tooltipTheme.waitDuration ?? _defaultWaitDuration;
     showDuration = tooltipTheme.showDuration ?? _getDefaultShowDuration();
@@ -450,6 +441,7 @@ class _TooltipOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print(decoration);
     return Positioned.fill(
       child: IgnorePointer(
         child: CustomSingleChildLayout(

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -27,7 +27,6 @@ class MacosTooltip extends StatefulWidget {
     Key? key,
     required this.message,
     this.child,
-    this.style,
     this.excludeFromSemantics = false,
     this.useMousePosition = true,
   }) : super(key: key);
@@ -38,10 +37,6 @@ class MacosTooltip extends StatefulWidget {
   /// The widget the tooltip will be displayed, either above or below,
   /// when the mouse is hovering or whenever it gets long pressed.
   final Widget? child;
-
-  /// The style of the tooltip. If non-null, it's mescled with
-  /// [ThemeData.tooltipThemeData]
-  final TooltipThemeData? style;
 
   /// Whether the tooltip's [message] should be excluded from the
   /// semantics tree.
@@ -390,19 +385,16 @@ class _TooltipOverlay extends StatelessWidget {
             opacity: animation,
             child: ConstrainedBox(
               constraints: BoxConstraints(minHeight: height),
-              child: DefaultTextStyle(
-                style: MacosTheme.of(context).typography.body,
-                child: Container(
-                  decoration: decoration,
-                  padding: padding,
-                  margin: margin,
-                  child: Center(
-                    widthFactor: 1.0,
-                    heightFactor: 1.0,
-                    child: Text(
-                      message,
-                      style: textStyle,
-                    ),
+              child: Container(
+                decoration: decoration,
+                padding: padding,
+                margin: margin,
+                child: Center(
+                  widthFactor: 1.0,
+                  heightFactor: 1.0,
+                  child: Text(
+                    message,
+                    style: textStyle,
                   ),
                 ),
               ),

--- a/lib/src/layout/toolbar/custom_toolbar_item.dart
+++ b/lib/src/layout/toolbar/custom_toolbar_item.dart
@@ -30,6 +30,7 @@ class CustomToolbarItem extends ToolbarItem {
     Key? key,
     required this.inToolbarBuilder,
     this.inOverflowedBuilder,
+    this.tooltipMessage,
   }) : super(key: key);
 
   /// Builds a custom widget to include in the [Toolbar].
@@ -45,10 +46,21 @@ class CustomToolbarItem extends ToolbarItem {
   /// Defaults to [SizedBox.shrink].
   final WidgetBuilder? inOverflowedBuilder;
 
+  /// An optional message to appear in a tooltip when user hovers over the
+  /// custom toolbar item.
+  final String? tooltipMessage;
+
   @override
   Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
-      return inToolbarBuilder(context);
+      Widget _widget = inToolbarBuilder(context);
+      if (tooltipMessage != null) {
+        _widget = MacosTooltip(
+          message: tooltipMessage!,
+          child: _widget,
+        );
+      }
+      return _widget;
     } else {
       return (inOverflowedBuilder != null)
           ? inOverflowedBuilder!(context)

--- a/lib/src/layout/toolbar/overflow_handler.dart
+++ b/lib/src/layout/toolbar/overflow_handler.dart
@@ -399,7 +399,6 @@ class RenderOverflowHandler extends RenderBox
     bool flipCrossAxis = false;
 
     childConstraints = BoxConstraints(maxWidth: constraints.maxWidth);
-    //TODO:
     mainAxisLimit = constraints.maxWidth - _overflowBreakpoint;
     if (textDirection == TextDirection.rtl) flipMainAxis = true;
 

--- a/lib/src/layout/toolbar/toolbar_divider.dart
+++ b/lib/src/layout/toolbar/toolbar_divider.dart
@@ -1,0 +1,37 @@
+import 'package:macos_ui/macos_ui.dart';
+import 'package:macos_ui/src/library.dart';
+
+/// A macOS-styled divider for the toolbar.
+class ToolBarDivider extends ToolbarItem {
+  /// Builds a macOS-styled divider for the toolbar. It generates a vertical
+  /// line (or a horizontal line, if it appears in the overflowed menu) between
+  /// the toolbar actions.
+  const ToolBarDivider({
+    Key? key,
+    this.padding = const EdgeInsets.all(6.0),
+  }) : super(key: key);
+
+  /// Optional padding to use for the divider.
+  ///
+  /// Defaults to EdgeInsets.all(6.0).
+  final EdgeInsets? padding;
+
+  @override
+  Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
+    Color _color = MacosTheme.brightnessOf(context).resolve(
+      const Color.fromRGBO(0, 0, 0, 0.25),
+      const Color.fromRGBO(255, 255, 255, 0.25),
+    );
+    if (displayMode == ToolbarItemDisplayMode.inToolbar) {
+      return Padding(
+        padding: padding!,
+        child: Container(color: _color, width: 1, height: 28),
+      );
+    } else {
+      return Padding(
+        padding: padding!,
+        child: Container(color: _color, height: 1),
+      );
+    }
+  }
+}

--- a/lib/src/theme/scrollbar_theme.dart
+++ b/lib/src/theme/scrollbar_theme.dart
@@ -89,7 +89,7 @@ class ScrollbarThemeData with Diagnosticable {
   final double? thickness;
 
   /// Overrides the default value of [MacosScrollbar.hoverThickness] in all
-  /// descendant [MacosScrollbar] widgtes when hovering is active.
+  /// descendant [MacosScrollbar] widgets when hovering is active.
   final double? hoveringThickness;
 
   /// Overrides the default value of [MacosScrollbar.showTrackOnHover] in all

--- a/lib/src/theme/tooltip_theme.dart
+++ b/lib/src/theme/tooltip_theme.dart
@@ -22,27 +22,44 @@ class TooltipThemeData with Diagnosticable {
     required TextStyle textStyle,
   }) {
     return TooltipThemeData(
-      height: 32.0,
-      verticalOffset: 24.0,
-      preferBelow: false,
+      height: 20.0,
+      verticalOffset: 18.0,
+      preferBelow: true,
       margin: EdgeInsets.zero,
-      padding: const EdgeInsets.symmetric(horizontal: 10.0),
+      padding: const EdgeInsets.symmetric(horizontal: 6.0),
       waitDuration: const Duration(seconds: 1),
       textStyle: textStyle,
       decoration: () {
-        const radius = BorderRadius.zero;
-        final shadow = kElevationToShadow[4];
+        final radius = BorderRadius.circular(2.0);
+        final shadow = [
+          BoxShadow(
+            color: brightness == Brightness.light
+                ? CupertinoColors.systemGrey3.color.withOpacity(0.5)
+                : CupertinoColors.black.withOpacity(0.5),
+            offset: const Offset(0, 2),
+            spreadRadius: 0.5,
+            blurRadius: 4,
+          ),
+        ];
+        final border = Border.all(
+          width: 0.5,
+          color: brightness == Brightness.light
+              ? CupertinoColors.systemGrey3.color
+              : CupertinoColors.systemGrey3.darkColor,
+        );
         if (brightness == Brightness.light) {
           return BoxDecoration(
-            color: CupertinoColors.systemGrey6.color,
+            color: Color(0xFFE1E3E5),
             borderRadius: radius,
             boxShadow: shadow,
+            border: border,
           );
         } else {
           return BoxDecoration(
-            color: CupertinoColors.systemGrey6.darkColor,
+            color: Color(0xFF1C1C1E),
             borderRadius: radius,
             boxShadow: shadow,
+            border: border,
           );
         }
       }(),

--- a/lib/src/theme/tooltip_theme.dart
+++ b/lib/src/theme/tooltip_theme.dart
@@ -1,5 +1,47 @@
 import 'package:flutter/foundation.dart';
+import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
+
+/// Overrides the default style of its [MacosTooltip] descendants.
+///
+/// See also:
+///
+///  * [MacosTooltipThemeData], which is used to configure this theme.
+class TooltipTheme extends InheritedTheme {
+  /// Builds a [MacosTooltipTheme].
+  ///
+  /// The data argument must not be null.
+  const TooltipTheme({
+    Key? key,
+    required this.data,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  /// The configuration for this theme
+  final TooltipThemeData data;
+
+  /// Returns the [data] from the closest [TooltipTheme] ancestor. If there is
+  /// no ancestor, it returns [MacosThemeData.tooltipTheme].
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// TooltipThemeData theme = TooltipTheme.of(context);
+  /// ```
+  static TooltipThemeData of(BuildContext context) {
+    final TooltipTheme? tooltipTheme =
+        context.dependOnInheritedWidgetOfExactType<TooltipTheme>();
+    return tooltipTheme?.data ?? MacosTheme.of(context).tooltipTheme;
+  }
+
+  @override
+  Widget wrap(BuildContext context, Widget child) {
+    return TooltipTheme(data: data, child: child);
+  }
+
+  @override
+  bool updateShouldNotify(TooltipTheme oldWidget) => data != oldWidget.data;
+}
 
 class TooltipThemeData with Diagnosticable {
   const TooltipThemeData({
@@ -16,7 +58,7 @@ class TooltipThemeData with Diagnosticable {
 
   /// Creates a default tooltip theme.
   ///
-  /// [textStyle] is usually [MacosTypography.caption2]
+  /// [textStyle] is usually [MacosTypography.callout]
   factory TooltipThemeData.standard({
     required Brightness brightness,
     required TextStyle textStyle,
@@ -28,14 +70,18 @@ class TooltipThemeData with Diagnosticable {
       margin: EdgeInsets.zero,
       padding: const EdgeInsets.symmetric(horizontal: 6.0),
       waitDuration: const Duration(seconds: 1),
-      textStyle: textStyle,
+      showDuration: const Duration(seconds: 10),
+      textStyle: textStyle.copyWith(
+        color:
+            brightness.isDark ? CupertinoColors.white : CupertinoColors.black,
+      ),
       decoration: () {
         final radius = BorderRadius.circular(2.0);
         final shadow = [
           BoxShadow(
-            color: brightness == Brightness.light
-                ? CupertinoColors.systemGrey3.color.withOpacity(0.5)
-                : CupertinoColors.black.withOpacity(0.5),
+            color: brightness.isDark
+                ? CupertinoColors.black.withOpacity(0.5)
+                : CupertinoColors.systemGrey3.color.withOpacity(0.5),
             offset: const Offset(0, 2),
             spreadRadius: 0.5,
             blurRadius: 4,
@@ -43,20 +89,20 @@ class TooltipThemeData with Diagnosticable {
         ];
         final border = Border.all(
           width: 0.5,
-          color: brightness == Brightness.light
-              ? CupertinoColors.systemGrey3.color
-              : CupertinoColors.systemGrey3.darkColor,
+          color: brightness.isDark
+              ? CupertinoColors.systemGrey3.darkColor
+              : CupertinoColors.systemGrey3.color,
         );
-        if (brightness == Brightness.light) {
+        if (brightness.isDark) {
           return BoxDecoration(
-            color: Color(0xFFE1E3E5),
+            color: const Color(0xFF1C1C1E),
             borderRadius: radius,
             boxShadow: shadow,
             border: border,
           );
         } else {
           return BoxDecoration(
-            color: Color(0xFF1C1C1E),
+            color: const Color(0xFFE1E3E5),
             borderRadius: radius,
             boxShadow: shadow,
             border: border,
@@ -66,7 +112,65 @@ class TooltipThemeData with Diagnosticable {
     );
   }
 
-  /// Copy this tooltip with [style]
+  /// The height of the tooltip's [child].
+  ///
+  /// If the [child] is null, then this is the tooltip's intrinsic height.
+  final double? height;
+
+  /// The vertical gap between the widget and the displayed tooltip.
+  ///
+  /// When [preferBelow] is set to true and tooltips have sufficient space
+  /// to display themselves, this property defines how much vertical space
+  /// tooltips will position themselves under their corresponding widgets.
+  /// Otherwise, tooltips will position themselves above their corresponding
+  /// widgets with the given offset.
+  final double? verticalOffset;
+
+  /// The amount of space by which to inset the tooltip's [child].
+  ///
+  /// Defaults to 6.0 logical pixels in the horizontal direction.
+  final EdgeInsetsGeometry? padding;
+
+  /// The empty space that surrounds the tooltip.
+  ///
+  /// Defines the tooltip's outer [Container.margin]. By default, a long
+  /// tooltip will span the width of its window. If long enough, a tooltip
+  /// might also span the window's height. This property allows one to define
+  /// how much space the tooltip must be inset from the edges of their display
+  /// window.
+  final EdgeInsetsGeometry? margin;
+
+  /// Whether the tooltip defaults to being displayed below the widget.
+  ///
+  /// Defaults to true. If there is insufficient space to display the tooltip
+  /// in the preferred direction, the tooltip will be displayed in the opposite
+  /// direction.
+  final bool? preferBelow;
+
+  /// Specifies the tooltip's shape and background color.
+  ///
+  /// The tooltip shape defaults to a rounded rectangle with a border radius of 2.0.
+  final Decoration? decoration;
+
+  /// The length of time that a pointer must hover over a tooltip's widget before
+  /// the tooltip will be shown.
+  ///
+  /// Once the pointer leaves the widget, the tooltip will immediately disappear.
+  ///
+  /// Defaults to 0 milliseconds (tooltips are shown immediately upon hover).
+  final Duration? waitDuration;
+
+  /// The length of time that the tooltip will be shown after a long press is released.
+  ///
+  /// Defaults to 10 seconds.
+  final Duration? showDuration;
+
+  /// The style to use for the message of the tooltip.
+  ///
+  /// If null, [MacosTypography.callout] is used
+  final TextStyle? textStyle;
+
+  /// Copies this [TooltipThemeData] into another.
   TooltipThemeData copyWith({
     Decoration? decoration,
     double? height,
@@ -91,67 +195,6 @@ class TooltipThemeData with Diagnosticable {
     );
   }
 
-  /// The height of the tooltip's [child].
-  ///
-  /// If the [child] is null, then this is the tooltip's intrinsic height.
-  final double? height;
-
-  /// The vertical gap between the widget and the displayed tooltip.
-  ///
-  /// When [preferBelow] is set to true and tooltips have sufficient space
-  /// to display themselves, this property defines how much vertical space
-  /// tooltips will position themselves under their corresponding widgets.
-  /// Otherwise, tooltips will position themselves above their corresponding
-  /// widgets with the given offset.
-  final double? verticalOffset;
-
-  /// The amount of space by which to inset the tooltip's [child].
-  ///
-  /// Defaults to 10.0 logical pixels in each direction.
-  final EdgeInsetsGeometry? padding;
-
-  /// The empty space that surrounds the tooltip.
-  ///
-  /// Defines the tooltip's outer [Container.margin]. By default, a long
-  /// tooltip will span the width of its window. If long enough, a tooltip
-  /// might also span the window's height. This property allows one to define
-  /// how much space the tooltip must be inset from the edges of their display
-  /// window.
-  final EdgeInsetsGeometry? margin;
-
-  /// Whether the tooltip defaults to being displayed below the widget.
-  ///
-  /// Defaults to true. If there is insufficient space to display the tooltip
-  /// in the preferred direction, the tooltip will be displayed in the opposite
-  /// direction.
-  final bool? preferBelow;
-
-  /// Specifies the tooltip's shape and background color.
-  ///
-  /// The tooltip shape defaults to a rounded rectangle with a border radius of 4.0.
-  /// Tooltips will also default to an opacity of 90% and with the color [CupertinoColors.systemGrey]
-  /// if [ThemeData.brightness] is [Brightness.dark], and [CupertinoColors.white] if
-  /// it is [Brightness.light].
-  final Decoration? decoration;
-
-  /// The length of time that a pointer must hover over a tooltip's widget before
-  /// the tooltip will be shown.
-  ///
-  /// Once the pointer leaves the widget, the tooltip will immediately disappear.
-  ///
-  /// Defaults to 0 milliseconds (tooltips are shown immediately upon hover).
-  final Duration? waitDuration;
-
-  /// The length of time that the tooltip will be shown after a long press is released.
-  ///
-  /// If on desktop, defaults to 10 seconds, otherwise, defaults to 1.5 seconds.
-  final Duration? showDuration;
-
-  /// The style to use for the message of the tooltip.
-  ///
-  /// If null, [MacosTypography.caption] is used
-  final TextStyle? textStyle;
-
   /// Linearly interpolate between two tooltip themes.
   ///
   /// All the properties must be non-null.
@@ -170,6 +213,21 @@ class TooltipThemeData with Diagnosticable {
       textStyle: TextStyle.lerp(a.textStyle, b.textStyle, t),
       verticalOffset: t < 0.5 ? a.verticalOffset : b.verticalOffset,
       waitDuration: t < 0.5 ? a.waitDuration : b.waitDuration,
+    );
+  }
+
+  TooltipThemeData merge(TooltipThemeData? other) {
+    if (other == null) return this;
+    return copyWith(
+      decoration: other.decoration,
+      height: other.height,
+      margin: other.margin,
+      padding: other.padding,
+      preferBelow: other.preferBelow,
+      showDuration: other.showDuration,
+      textStyle: other.textStyle,
+      verticalOffset: other.verticalOffset,
+      waitDuration: other.waitDuration,
     );
   }
 
@@ -220,20 +278,5 @@ class TooltipThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<Duration>('waitDuration', waitDuration));
     properties.add(DiagnosticsProperty<Duration>('showDuration', showDuration));
     properties.add(DiagnosticsProperty<TextStyle>('textStyle', textStyle));
-  }
-
-  TooltipThemeData merge(TooltipThemeData? other) {
-    if (other == null) return this;
-    return copyWith(
-      decoration: other.decoration,
-      height: other.height,
-      margin: other.margin,
-      padding: other.padding,
-      preferBelow: other.preferBelow,
-      showDuration: other.showDuration,
-      textStyle: other.textStyle,
-      verticalOffset: other.verticalOffset,
-      waitDuration: other.waitDuration,
-    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.1.0
+version: 1.2.0
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:

--- a/test/labels/tooltip_test.dart
+++ b/test/labels/tooltip_test.dart
@@ -21,7 +21,7 @@ void _ensureTooltipVisible(GlobalKey key) {
   (key.currentState as dynamic).ensureTooltipVisible();
 }
 
-const String tooltipText = 'TIP';
+const String tooltipText = 'A message for the tooltip';
 
 Finder _findTooltipContainer(String tooltipText) {
   return find.ancestor(
@@ -32,7 +32,7 @@ Finder _findTooltipContainer(String tooltipText) {
 
 void main() {
   testWidgets(
-    'Does tooltip end up in the right place - center',
+    'Does tooltip end up in the right place - left aligned, below the widget',
     (tester) async {
       final key = GlobalKey();
       await tester.pumpWidget(
@@ -76,9 +76,9 @@ void main() {
       final RenderBox tip = tester.renderObject(
         _findTooltipContainer(tooltipText),
       );
-      final tipInGlobal = tip.localToGlobal(tip.size.topCenter(Offset.zero));
+      final tipInGlobal = tip.localToGlobal(tip.size.topLeft(Offset.zero));
       expect(tipInGlobal.dx, 300.0);
-      expect(tipInGlobal.dy, 24.0);
+      expect(tipInGlobal.dy, 18.0);
     },
   );
 }


### PR DESCRIPTION
This PR includes:

## Improved `MacosTooltip`

While working on the rest of the PR's items, I found that the current `MacosTooltip` was a bit different than the one used in Apple design, so I decided to work on this as well. 

Before:

<img width="291" alt="Screenshot 2022-05-08 at 10 22 24 PM" src="https://user-images.githubusercontent.com/9117427/167312346-a43c0ceb-8e02-4dc8-a405-8c6def2df82f.png">

After:

<img width="353" alt="Screenshot 2022-05-08 at 4 56 05 PM" src="https://user-images.githubusercontent.com/9117427/167312327-5dd1783f-415c-4d16-b2a5-dc56e365d2d5.png">

<img width="334" alt="Screenshot 2022-05-08 at 4 56 55 PM" src="https://user-images.githubusercontent.com/9117427/167312329-57a44782-ea2c-4531-a8ae-cfd629f000b3.png">

Apple design (Finder app):

<img width="306" alt="Screenshot 2022-05-08 at 10 23 06 PM" src="https://user-images.githubusercontent.com/9117427/167312359-ca1e3139-14f1-42b3-a72d-f2d8dcae01f3.png">

To sum up the changes:
- Different color, padding and shadows.
- The tooltip now appears left-aligned, below the mouse cursor.

In implementing the above, I also noticed that the way that theme values were passed to the widget was different from how we do it for other components. So, I refactored some of its methods and got rid of some that weren't used at all, to have it work similarly to the rest of the widgets. To sum up:

- Added a `TooltipTheme` (previously it was derived straight from the MacosTheme's TooltipThemeData).
- Tooltip's styling can now be controlled fully via the current `TooltipTheme`, with the standard one being the Apple design default.

## Tooltip property for Toolbar items

Can now use an optional `tooltipMessage` property for all ToolBar items, to have a `MacosTooltip` shown below on hover. Closes #232 .

## ToolbarDivider widget

A simple utility widget to display a divider between toolbar items. Below screen from the example app and the Notes app for comparison:

<img width="791" alt="Screenshot 2022-05-07 at 10 58 48 PM" src="https://user-images.githubusercontent.com/9117427/167312680-7237abb7-a623-4c62-8996-23cb12c26f6b.png">

Closes #231.

## Pre-launch Checklist

- [👍 ] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [ 👍 ] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [👍  ] I have added/updated relevant documentation <!-- If relevant -->
- [👍  ] I have run "optimize/organize imports" on all changed files
- [👍  ] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->