### PR TITLE
Fix toolbar `actions` RangeError (closes #239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.2.1]
+* Fixes issue with error thrown when toolbar actions are modified programmatically [#239](https://github.com/GroovinChip/macos_ui/issues/239) 
+
 ## [1.2.0]
 * Improved styling for `MacosTooltip`:
   * Better color and shadows.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/toolbar/toolbar.dart
+++ b/lib/src/layout/toolbar/toolbar.dart
@@ -179,7 +179,7 @@ class _ToolBarState extends State<ToolBar> {
 
     // Collect the toolbar action widgets that can be shown inside the ToolBar
     // and the ones that have overflowed.
-    late List<ToolbarItem>? _inToolbarActions;
+    List<ToolbarItem>? _inToolbarActions = [];
     List<ToolbarItem> _overflowedActions = [];
     bool doAllItemsShowLabel = true;
     if (widget.actions != null && widget.actions!.isNotEmpty) {
@@ -241,7 +241,7 @@ class _ToolBarState extends State<ToolBar> {
                         .toList(),
                   ),
                 ),
-                children: _inToolbarActions!
+                children: _inToolbarActions
                     .map((e) =>
                         e.build(context, ToolbarItemDisplayMode.inToolbar))
                     .toList(),

--- a/lib/src/layout/toolbar/toolbar.dart
+++ b/lib/src/layout/toolbar/toolbar.dart
@@ -123,7 +123,16 @@ class ToolBar extends StatefulWidget {
 }
 
 class _ToolBarState extends State<ToolBar> {
-  List<int> overflowedActionsIndexes = [];
+  int overflowedActionsCount = 0;
+
+  @override
+  void didUpdateWidget(ToolBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.actions != null &&
+        widget.actions!.length != oldWidget.actions!.length) {
+      overflowedActionsCount = 0;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -170,13 +179,13 @@ class _ToolBarState extends State<ToolBar> {
 
     // Collect the toolbar action widgets that can be shown inside the ToolBar
     // and the ones that have overflowed.
-    List<ToolbarItem>? _inToolbarActions = [];
-    late List<ToolbarItem> _overflowedActions;
+    late List<ToolbarItem>? _inToolbarActions;
+    List<ToolbarItem> _overflowedActions = [];
     bool doAllItemsShowLabel = true;
     if (widget.actions != null && widget.actions!.isNotEmpty) {
-      _inToolbarActions = widget.actions!;
-      _overflowedActions = overflowedActionsIndexes
-          .map((index) => widget.actions![index])
+      _inToolbarActions = widget.actions ?? [];
+      _overflowedActions = _inToolbarActions
+          .sublist(_inToolbarActions.length - overflowedActionsCount)
           .toList();
       // If all toolbar actions have labels shown below their icons,
       // reduce the overflow button's size as well.
@@ -232,12 +241,12 @@ class _ToolBarState extends State<ToolBar> {
                         .toList(),
                   ),
                 ),
-                children: _inToolbarActions
+                children: _inToolbarActions!
                     .map((e) =>
                         e.build(context, ToolbarItemDisplayMode.inToolbar))
                     .toList(),
                 overflowChangedCallback: (hiddenItems) {
-                  setState(() => overflowedActionsIndexes = hiddenItems);
+                  setState(() => overflowedActionsCount = hiddenItems.length);
                 },
               ),
               middleSpacing: 8,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.2.0
+version: 1.2.1
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:


### PR DESCRIPTION
Fixes the error thrown when modifying the `actions` list of a toolbar after initialization.

Adds a `didUpdateWidget` method to the `Toolbar`, in order to track modifications to the widget's `actions` property. If it has changed for any reason, it forces a recalculation of the overflowed widgets.

Also simplifies how we track which actions have overflowed. Instead of checking their indexes, we now just count how many of them (`overflowedActionsCount`) should be hidden, and slice the end of the `actions` array accordingly.

Closes #239.

## Pre-launch Checklist

- [👍 ] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [ 👍 ] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [] I have added/updated relevant documentation <!-- If relevant -->
- [ 👍 ] I have run "optimize/organize imports" on all changed files
- [ 👍 ] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->