### PR TITLE
Flutter 3 upgrade & MacosColor update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.4.0]
+* Migrate to Flutter 3.0
+  * Minimumin dart sdk version is now 2.17.0
+  * Update to `flutter_lints: ^2.0.1` with subsequent fixes
+  * `MacosScrollbar` API more closely matches its material counterpart 
+
 ## [1.3.0]
 * Add a `top` property to `Sidebar`
 * Tweak the default `primaryColor` value in `MacosThemeData`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   * Use new super parameters feature
   * Update to `flutter_lints: ^2.0.1` with subsequent fixes
   * `MacosScrollbar` API more closely matches its material counterpart 
+* Update `MacosColor` to more closely match the `Color` class
+  * Adds `MacosColor.fromARGB` constructor
+  * Adds `MacosColor.fromRGBO` constructor
+  * Adds `alphaBlend` function
+  * Adds `getAlphaFromOpacity` function
 
 ## [1.3.0]
 * Add a `top` property to `Sidebar`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.4.0]
 * Migrate to Flutter 3.0
   * Minimumin dart sdk version is now 2.17.0
+  * Use new super parameters feature
   * Update to `flutter_lints: ^2.0.1` with subsequent fixes
   * `MacosScrollbar` API more closely matches its material counterpart 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.4.0]
-* Migrate to Flutter 3.0
-  * Minimumin dart sdk version is now 2.17.0
+* Migration to Flutter 3.0
+  * Minimum dart sdk version is now 2.17.0
   * Use new super parameters feature
   * Update to `flutter_lints: ^2.0.1` with subsequent fixes
   * `MacosScrollbar` API more closely matches its material counterpart 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,8 @@
 include: package:flutter_lints/flutter.yaml
 
-#linter:
-#  rules:
-#    - avoid_relative_lib_imports
-#    - prefer_const_constructors
-#    - use_key_in_widget_constructors
+linter:
+  rules:
+    - use_super_parameters: true
 
 analyzer:
   plugins:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,7 +2,7 @@ include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    - use_super_parameters: true
+    - use_super_parameters
 
 analyzer:
   plugins:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -22,7 +22,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    - use_super_parameters: true
+    - use_super_parameters
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -22,8 +22,7 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    - use_super_parameters: true
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,11 +12,11 @@ import 'package:provider/provider.dart';
 import 'theme.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const MacosUIGalleryApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+class MacosUIGalleryApp extends StatelessWidget {
+  const MacosUIGalleryApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -25,26 +25,26 @@ class MyApp extends StatelessWidget {
       builder: (context, _) {
         final appTheme = context.watch<AppTheme>();
         return MacosApp(
-          title: 'macos_ui example',
+          title: 'macos_ui Widget Gallery',
           theme: MacosThemeData.light(),
           darkTheme: MacosThemeData.dark(),
           themeMode: appTheme.mode,
           debugShowCheckedModeBanner: false,
-          home: const Demo(),
+          home: const WidgetGallery(),
         );
       },
     );
   }
 }
 
-class Demo extends StatefulWidget {
-  const Demo({Key? key}) : super(key: key);
+class WidgetGallery extends StatefulWidget {
+  const WidgetGallery({Key? key}) : super(key: key);
 
   @override
-  _DemoState createState() => _DemoState();
+  State<WidgetGallery> createState() => _WidgetGalleryState();
 }
 
-class _DemoState extends State<Demo> {
+class _WidgetGalleryState extends State<WidgetGallery> {
   double ratingValue = 0;
   double sliderValue = 0;
   bool value = false;
@@ -73,14 +73,6 @@ class _DemoState extends State<Demo> {
   @override
   Widget build(BuildContext context) {
     return MacosWindow(
-      child: IndexedStack(
-        index: pageIndex,
-        children: pages,
-      ),
-      // Optional title bar:
-      // titleBar: const TitleBar(
-      //   title: Text('macOS App Name'),
-      // ),
       sidebar: Sidebar(
         top: MacosSearchField(
           placeholder: 'Search',
@@ -195,6 +187,10 @@ class _DemoState extends State<Demo> {
           title: Text('Tim Apple'),
           subtitle: Text('tim@apple.com'),
         ),
+      ),
+      child: IndexedStack(
+        index: pageIndex,
+        children: pages,
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-
 import 'package:example/pages/buttons_page.dart';
 import 'package:example/pages/colors_page.dart';
 import 'package:example/pages/dialogs_page.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:example/pages/buttons_page.dart';
 import 'package:example/pages/colors_page.dart';
 import 'package:example/pages/dialogs_page.dart';
@@ -6,10 +8,15 @@ import 'package:example/pages/indicators_page.dart';
 import 'package:example/pages/selectors_page.dart';
 import 'package:example/pages/toolbar_page.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:provider/provider.dart';
 
 import 'theme.dart';
+
+enum MenuSelection {
+  about,
+}
 
 void main() {
   runApp(const MacosUIGalleryApp());
@@ -70,127 +77,180 @@ class _WidgetGalleryState extends State<WidgetGallery> {
     const SelectorsPage(),
   ];
 
+  void _handleMenuSelection(MenuSelection value) {
+    switch (value) {
+      case MenuSelection.about:
+        showMacosAlertDialog(
+          context: context,
+          builder: (_) => const MacosAlertDialog(
+            appIcon: FlutterLogo(),
+            title: Text('macos_ui'),
+            message: Text('Version 1.4.0'),
+            primaryButton: PushButton(
+              buttonSize: ButtonSize.large,
+              child: Text('Close'),
+            ),
+          ),
+        );
+        break;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return MacosWindow(
-      sidebar: Sidebar(
-        top: MacosSearchField(
-          placeholder: 'Search',
-          controller: searchFieldController,
-          onResultSelected: (result) {
-            switch (result.searchKey) {
-              case 'Buttons':
-                setState(() {
-                  pageIndex = 0;
-                  searchFieldController.clear();
-                });
-                break;
-              case 'Indicators':
-                setState(() {
-                  pageIndex = 1;
-                  searchFieldController.clear();
-                });
-                break;
-              case 'Fields':
-                setState(() {
-                  pageIndex = 2;
-                  searchFieldController.clear();
-                });
-                break;
-              case 'Colors':
-                setState(() {
-                  pageIndex = 3;
-                  searchFieldController.clear();
-                });
-                break;
-              case 'Dialogs and Sheets':
-                setState(() {
-                  pageIndex = 5;
-                  searchFieldController.clear();
-                });
-                break;
-              case 'Toolbar':
-                setState(() {
-                  pageIndex = 6;
-                  searchFieldController.clear();
-                });
-                break;
-              case 'Selectors':
-                setState(() {
-                  pageIndex = 7;
-                  searchFieldController.clear();
-                });
-                break;
-              default:
-                searchFieldController.clear();
-            }
-          },
-          results: const [
-            SearchResultItem('Buttons'),
-            SearchResultItem('Indicators'),
-            SearchResultItem('Fields'),
-            SearchResultItem('Colors'),
-            SearchResultItem('Dialogs and Sheets'),
-            SearchResultItem('Toolbar'),
-            SearchResultItem('Selectors'),
+    return PlatformMenuBar(
+      menus: const [
+        PlatformMenu(
+          label: 'macos_ui Widget Gallery',
+          menus: [
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.about,
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.quit,
+            ),
           ],
         ),
-        minWidth: 200,
-        builder: (context, controller) {
-          return SidebarItems(
-            currentIndex: pageIndex,
-            onChanged: (i) => setState(() => pageIndex = i),
-            scrollController: controller,
-            items: const [
-              SidebarItem(
-                leading: MacosIcon(CupertinoIcons.square_on_circle),
-                label: Text('Buttons'),
-              ),
-              SidebarItem(
-                leading: MacosIcon(CupertinoIcons.arrow_2_circlepath),
-                label: Text('Indicators'),
-              ),
-              SidebarItem(
-                leading: MacosIcon(CupertinoIcons.textbox),
-                label: Text('Fields'),
-              ),
-              SidebarItem(
-                label: Text('Disclosure'),
-                disclosureItems: [
-                  SidebarItem(
-                    leading: MacosIcon(CupertinoIcons.infinite),
-                    label: Text('Colors'),
-                  ),
-                  SidebarItem(
-                    leading: MacosIcon(CupertinoIcons.infinite),
-                    label: Text('Item 3'),
-                  ),
-                ],
-              ),
-              SidebarItem(
-                leading: MacosIcon(CupertinoIcons.rectangle),
-                label: Text('Dialogs & Sheets'),
-              ),
-              SidebarItem(
-                leading: MacosIcon(CupertinoIcons.macwindow),
-                label: Text('Toolbar'),
-              ),
-              SidebarItem(
-                leading: MacosIcon(CupertinoIcons.calendar),
-                label: Text('Selectors'),
-              ),
-            ],
-          );
-        },
-        bottom: const MacosListTile(
-          leading: MacosIcon(CupertinoIcons.profile_circled),
-          title: Text('Tim Apple'),
-          subtitle: Text('tim@apple.com'),
+        PlatformMenu(
+          label: 'View',
+          menus: [
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.toggleFullScreen,
+            ),
+          ],
         ),
-      ),
-      child: IndexedStack(
-        index: pageIndex,
-        children: pages,
+        PlatformMenu(
+          label: 'Window',
+          menus: [
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.minimizeWindow,
+            ),
+            PlatformProvidedMenuItem(
+              type: PlatformProvidedMenuItemType.zoomWindow,
+            ),
+          ],
+        ),
+      ],
+      body: MacosWindow(
+        sidebar: Sidebar(
+          top: MacosSearchField(
+            placeholder: 'Search',
+            controller: searchFieldController,
+            onResultSelected: (result) {
+              switch (result.searchKey) {
+                case 'Buttons':
+                  setState(() {
+                    pageIndex = 0;
+                    searchFieldController.clear();
+                  });
+                  break;
+                case 'Indicators':
+                  setState(() {
+                    pageIndex = 1;
+                    searchFieldController.clear();
+                  });
+                  break;
+                case 'Fields':
+                  setState(() {
+                    pageIndex = 2;
+                    searchFieldController.clear();
+                  });
+                  break;
+                case 'Colors':
+                  setState(() {
+                    pageIndex = 3;
+                    searchFieldController.clear();
+                  });
+                  break;
+                case 'Dialogs and Sheets':
+                  setState(() {
+                    pageIndex = 5;
+                    searchFieldController.clear();
+                  });
+                  break;
+                case 'Toolbar':
+                  setState(() {
+                    pageIndex = 6;
+                    searchFieldController.clear();
+                  });
+                  break;
+                case 'Selectors':
+                  setState(() {
+                    pageIndex = 7;
+                    searchFieldController.clear();
+                  });
+                  break;
+                default:
+                  searchFieldController.clear();
+              }
+            },
+            results: const [
+              SearchResultItem('Buttons'),
+              SearchResultItem('Indicators'),
+              SearchResultItem('Fields'),
+              SearchResultItem('Colors'),
+              SearchResultItem('Dialogs and Sheets'),
+              SearchResultItem('Toolbar'),
+              SearchResultItem('Selectors'),
+            ],
+          ),
+          minWidth: 200,
+          builder: (context, controller) {
+            return SidebarItems(
+              currentIndex: pageIndex,
+              onChanged: (i) => setState(() => pageIndex = i),
+              scrollController: controller,
+              items: const [
+                SidebarItem(
+                  leading: MacosIcon(CupertinoIcons.square_on_circle),
+                  label: Text('Buttons'),
+                ),
+                SidebarItem(
+                  leading: MacosIcon(CupertinoIcons.arrow_2_circlepath),
+                  label: Text('Indicators'),
+                ),
+                SidebarItem(
+                  leading: MacosIcon(CupertinoIcons.textbox),
+                  label: Text('Fields'),
+                ),
+                SidebarItem(
+                  label: Text('Disclosure'),
+                  disclosureItems: [
+                    SidebarItem(
+                      leading: MacosIcon(CupertinoIcons.infinite),
+                      label: Text('Colors'),
+                    ),
+                    SidebarItem(
+                      leading: MacosIcon(CupertinoIcons.infinite),
+                      label: Text('Item 3'),
+                    ),
+                  ],
+                ),
+                SidebarItem(
+                  leading: MacosIcon(CupertinoIcons.rectangle),
+                  label: Text('Dialogs & Sheets'),
+                ),
+                SidebarItem(
+                  leading: MacosIcon(CupertinoIcons.macwindow),
+                  label: Text('Toolbar'),
+                ),
+                SidebarItem(
+                  leading: MacosIcon(CupertinoIcons.calendar),
+                  label: Text('Selectors'),
+                ),
+              ],
+            );
+          },
+          bottom: const MacosListTile(
+            leading: MacosIcon(CupertinoIcons.profile_circled),
+            title: Text('Tim Apple'),
+            subtitle: Text('tim@apple.com'),
+          ),
+        ),
+        child: IndexedStack(
+          index: pageIndex,
+          children: pages,
+        ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,10 +11,6 @@ import 'package:provider/provider.dart';
 
 import 'theme.dart';
 
-enum MenuSelection {
-  about,
-}
-
 void main() {
   runApp(const MacosUIGalleryApp());
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 
 import 'package:example/pages/buttons_page.dart';
 import 'package:example/pages/colors_page.dart';

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:example/pages/indicators_page.dart';
 import 'package:example/pages/selectors_page.dart';
 import 'package:example/pages/toolbar_page.dart';
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:provider/provider.dart';
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,7 +16,7 @@ void main() {
 }
 
 class MacosUIGalleryApp extends StatelessWidget {
-  const MacosUIGalleryApp({Key? key}) : super(key: key);
+  const MacosUIGalleryApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +38,7 @@ class MacosUIGalleryApp extends StatelessWidget {
 }
 
 class WidgetGallery extends StatefulWidget {
-  const WidgetGallery({Key? key}) : super(key: key);
+  const WidgetGallery({super.key});
 
   @override
   State<WidgetGallery> createState() => _WidgetGalleryState();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -75,25 +75,6 @@ class _WidgetGalleryState extends State<WidgetGallery> {
     const SelectorsPage(),
   ];
 
-  void _handleMenuSelection(MenuSelection value) {
-    switch (value) {
-      case MenuSelection.about:
-        showMacosAlertDialog(
-          context: context,
-          builder: (_) => const MacosAlertDialog(
-            appIcon: FlutterLogo(),
-            title: Text('macos_ui'),
-            message: Text('Version 1.4.0'),
-            primaryButton: PushButton(
-              buttonSize: ButtonSize.large,
-              child: Text('Close'),
-            ),
-          ),
-        );
-        break;
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return PlatformMenuBar(

--- a/example/lib/pages/buttons_page.dart
+++ b/example/lib/pages/buttons_page.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import '../theme.dart';
 
 class ButtonsPage extends StatefulWidget {
-  const ButtonsPage({Key? key}) : super(key: key);
+  const ButtonsPage({super.key});
 
   @override
   State<ButtonsPage> createState() => _ButtonsPageState();

--- a/example/lib/pages/buttons_page.dart
+++ b/example/lib/pages/buttons_page.dart
@@ -9,7 +9,7 @@ class ButtonsPage extends StatefulWidget {
   const ButtonsPage({Key? key}) : super(key: key);
 
   @override
-  _ButtonsPageState createState() => _ButtonsPageState();
+  State<ButtonsPage> createState() => _ButtonsPageState();
 }
 
 class _ButtonsPageState extends State<ButtonsPage> {

--- a/example/lib/pages/colors_page.dart
+++ b/example/lib/pages/colors_page.dart
@@ -5,7 +5,7 @@ class ColorsPage extends StatefulWidget {
   const ColorsPage({Key? key}) : super(key: key);
 
   @override
-  _ColorsPageState createState() => _ColorsPageState();
+  State<ColorsPage> createState() => _ColorsPageState();
 }
 
 class _ColorsPageState extends State<ColorsPage> {

--- a/example/lib/pages/colors_page.dart
+++ b/example/lib/pages/colors_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:macos_ui/macos_ui.dart';
 
 class ColorsPage extends StatefulWidget {
-  const ColorsPage({Key? key}) : super(key: key);
+  const ColorsPage({super.key});
 
   @override
   State<ColorsPage> createState() => _ColorsPageState();
@@ -341,9 +341,9 @@ class _ColorsPageState extends State<ColorsPage> {
 
 class ColorBox extends StatelessWidget {
   const ColorBox({
-    Key? key,
+    super.key,
     required this.color,
-  }) : super(key: key);
+  });
 
   final Color color;
 

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -3,7 +3,7 @@ import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
 
 class DialogsPage extends StatefulWidget {
-  const DialogsPage({Key? key}) : super(key: key);
+  const DialogsPage({super.key});
 
   @override
   State<DialogsPage> createState() => _DialogsPageState();
@@ -179,7 +179,7 @@ class _DialogsPageState extends State<DialogsPage> {
 }
 
 class DoNotNotifyRow extends StatefulWidget {
-  const DoNotNotifyRow({Key? key}) : super(key: key);
+  const DoNotNotifyRow({super.key});
 
   @override
   State<DoNotNotifyRow> createState() => _DoNotNotifyRowState();
@@ -207,7 +207,7 @@ class _DoNotNotifyRowState extends State<DoNotNotifyRow> {
 }
 
 class MacosuiSheet extends StatelessWidget {
-  const MacosuiSheet({Key? key}) : super(key: key);
+  const MacosuiSheet({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/pages/dialogs_page.dart
+++ b/example/lib/pages/dialogs_page.dart
@@ -6,7 +6,7 @@ class DialogsPage extends StatefulWidget {
   const DialogsPage({Key? key}) : super(key: key);
 
   @override
-  _DialogsPageState createState() => _DialogsPageState();
+  State<DialogsPage> createState() => _DialogsPageState();
 }
 
 class _DialogsPageState extends State<DialogsPage> {
@@ -53,8 +53,8 @@ class _DialogsPageState extends State<DialogsPage> {
                         //horizontalActions: false,
                         primaryButton: PushButton(
                           buttonSize: ButtonSize.large,
-                          child: const Text('Primary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Primary'),
                         ),
                       ),
                     ),
@@ -79,14 +79,14 @@ class _DialogsPageState extends State<DialogsPage> {
                         //horizontalActions: false,
                         primaryButton: PushButton(
                           buttonSize: ButtonSize.large,
-                          child: const Text('Primary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Primary'),
                         ),
                         secondaryButton: PushButton(
                           buttonSize: ButtonSize.large,
                           isSecondary: true,
-                          child: const Text('Secondary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Secondary'),
                         ),
                       ),
                     ),
@@ -111,14 +111,14 @@ class _DialogsPageState extends State<DialogsPage> {
                         horizontalActions: false,
                         primaryButton: PushButton(
                           buttonSize: ButtonSize.large,
-                          child: const Text('Primary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Primary'),
                         ),
                         secondaryButton: PushButton(
                           buttonSize: ButtonSize.large,
                           isSecondary: true,
-                          child: const Text('Secondary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Secondary'),
                         ),
                       ),
                     ),
@@ -144,14 +144,14 @@ class _DialogsPageState extends State<DialogsPage> {
                         horizontalActions: false,
                         primaryButton: PushButton(
                           buttonSize: ButtonSize.large,
-                          child: const Text('Primary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Primary'),
                         ),
                         secondaryButton: PushButton(
                           buttonSize: ButtonSize.large,
                           isSecondary: true,
-                          child: const Text('Secondary'),
                           onPressed: Navigator.of(context).pop,
+                          child: const Text('Secondary'),
                         ),
                         suppress: const DoNotNotifyRow(),
                       ),
@@ -182,7 +182,7 @@ class DoNotNotifyRow extends StatefulWidget {
   const DoNotNotifyRow({Key? key}) : super(key: key);
 
   @override
-  _DoNotNotifyRowState createState() => _DoNotNotifyRowState();
+  State<DoNotNotifyRow> createState() => _DoNotNotifyRowState();
 }
 
 class _DoNotNotifyRowState extends State<DoNotNotifyRow> {

--- a/example/lib/pages/fields_page.dart
+++ b/example/lib/pages/fields_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart' hide OverlayVisibilityMode;
 import 'package:macos_ui/macos_ui.dart';
 
 class FieldsPage extends StatefulWidget {
-  const FieldsPage({Key? key}) : super(key: key);
+  const FieldsPage({super.key});
 
   @override
   State<FieldsPage> createState() => _FieldsPageState();

--- a/example/lib/pages/fields_page.dart
+++ b/example/lib/pages/fields_page.dart
@@ -5,7 +5,7 @@ class FieldsPage extends StatefulWidget {
   const FieldsPage({Key? key}) : super(key: key);
 
   @override
-  _FieldsPageState createState() => _FieldsPageState();
+  State<FieldsPage> createState() => _FieldsPageState();
 }
 
 class _FieldsPageState extends State<FieldsPage> {

--- a/example/lib/pages/indicators_page.dart
+++ b/example/lib/pages/indicators_page.dart
@@ -6,7 +6,7 @@ class IndicatorsPage extends StatefulWidget {
   const IndicatorsPage({Key? key}) : super(key: key);
 
   @override
-  _IndicatorsPageState createState() => _IndicatorsPageState();
+  State<IndicatorsPage> createState() => _IndicatorsPageState();
 }
 
 class _IndicatorsPageState extends State<IndicatorsPage> {

--- a/example/lib/pages/indicators_page.dart
+++ b/example/lib/pages/indicators_page.dart
@@ -3,7 +3,7 @@ import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
 
 class IndicatorsPage extends StatefulWidget {
-  const IndicatorsPage({Key? key}) : super(key: key);
+  const IndicatorsPage({super.key});
 
   @override
   State<IndicatorsPage> createState() => _IndicatorsPageState();

--- a/example/lib/pages/selectors_page.dart
+++ b/example/lib/pages/selectors_page.dart
@@ -2,9 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:macos_ui/macos_ui.dart';
 
 class SelectorsPage extends StatefulWidget {
-  const SelectorsPage({
-    Key? key,
-  }) : super(key: key);
+  const SelectorsPage({super.key});
 
   @override
   State<SelectorsPage> createState() => _SelectorsPageState();

--- a/example/lib/pages/toolbar_page.dart
+++ b/example/lib/pages/toolbar_page.dart
@@ -3,7 +3,7 @@ import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
 
 class ToolbarPage extends StatefulWidget {
-  const ToolbarPage({Key? key}) : super(key: key);
+  const ToolbarPage({super.key});
 
   @override
   State<ToolbarPage> createState() => _ToolbarPageState();

--- a/example/lib/pages/toolbar_page.dart
+++ b/example/lib/pages/toolbar_page.dart
@@ -6,7 +6,7 @@ class ToolbarPage extends StatefulWidget {
   const ToolbarPage({Key? key}) : super(key: key);
 
   @override
-  _ToolbarPageState createState() => _ToolbarPageState();
+  State<ToolbarPage> createState() => _ToolbarPageState();
 }
 
 class _ToolbarPageState extends State<ToolbarPage> {

--- a/example/macos/Runner/Configs/AppInfo.xcconfig
+++ b/example/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = example
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.example
+PRODUCT_BUNDLE_IDENTIFIER = dev.macosui.gallery
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2022 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2022 dev.macosui. All rights reserved.

--- a/example/macos/Runner/Info.plist
+++ b/example/macos/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>Widget Gallery</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -101,7 +101,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -122,7 +122,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   provider:
     dependency: "direct main"
     description:
@@ -141,7 +141,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -176,21 +176,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -68,7 +68,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,14 +80,14 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   macos_ui:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.3.0"
+    version: "1.4.0"
   matcher:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/lib/src/buttons/back_button.dart
+++ b/lib/src/buttons/back_button.dart
@@ -137,20 +137,20 @@ class MacosBackButtonState extends State<MacosBackButton>
         ? CupertinoColors.white
         : CupertinoColors.black;
 
-    Color? _fillColor;
+    Color? fillColor;
     if (widget.fillColor != null) {
-      _fillColor = widget.fillColor;
+      fillColor = widget.fillColor;
     } else {
-      _fillColor = brightness == Brightness.dark
+      fillColor = brightness == Brightness.dark
           ? const Color(0xff323232)
           : const Color(0xffF4F5F5);
     }
 
-    Color? _hoverColor;
+    Color? hoverColor;
     if (widget.hoverColor != null) {
-      _hoverColor = widget.hoverColor;
+      hoverColor = widget.hoverColor;
     } else {
-      _hoverColor = brightness == Brightness.dark
+      hoverColor = brightness == Brightness.dark
           ? const Color(0xff333336)
           : const Color(0xffF3F2F2);
     }
@@ -194,8 +194,8 @@ class MacosBackButtonState extends State<MacosBackButton>
                               ? const Color(0xff3C383C)
                               : const Color(0xffE5E5E5)
                           : _isHovered
-                              ? _hoverColor
-                              : _fillColor,
+                              ? hoverColor
+                              : fillColor,
                       borderRadius: BorderRadius.circular(7),
                     ),
                     child: Icon(

--- a/lib/src/buttons/back_button.dart
+++ b/lib/src/buttons/back_button.dart
@@ -7,13 +7,13 @@ class MacosBackButton extends StatefulWidget {
   /// Creates a `BackButton` with the appropriate icon/background colors based
   /// on light/dark themes.
   const MacosBackButton({
-    Key? key,
+    super.key,
     this.onPressed,
     this.fillColor,
     this.hoverColor,
     this.semanticLabel,
     this.mouseCursor = SystemMouseCursors.basic,
-  }) : super(key: key);
+  });
 
   /// An override callback to perform instead of the default behavior which is
   /// to pop the [Navigator].

--- a/lib/src/buttons/checkbox.dart
+++ b/lib/src/buttons/checkbox.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
@@ -13,7 +12,7 @@ class MacosCheckbox extends StatelessWidget {
   ///
   /// [size] must be non-negative
   const MacosCheckbox({
-    Key? key,
+    super.key,
     required this.value,
     required this.onChanged,
     this.size = 16.0,
@@ -21,8 +20,7 @@ class MacosCheckbox extends StatelessWidget {
     this.disabledColor = CupertinoColors.quaternaryLabel,
     this.offBorderColor = CupertinoColors.tertiaryLabel,
     this.semanticLabel,
-  })  : assert(size >= 0),
-        super(key: key);
+  })  : assert(size >= 0);
 
   /// Whether the checkbox is checked or not. If null, it'll be considered
   /// mixed.

--- a/lib/src/buttons/checkbox.dart
+++ b/lib/src/buttons/checkbox.dart
@@ -20,7 +20,7 @@ class MacosCheckbox extends StatelessWidget {
     this.disabledColor = CupertinoColors.quaternaryLabel,
     this.offBorderColor = CupertinoColors.tertiaryLabel,
     this.semanticLabel,
-  })  : assert(size >= 0);
+  }) : assert(size >= 0);
 
   /// Whether the checkbox is checked or not. If null, it'll be considered
   /// mixed.

--- a/lib/src/buttons/help_button.dart
+++ b/lib/src/buttons/help_button.dart
@@ -12,7 +12,7 @@ import 'package:macos_ui/src/library.dart';
 class HelpButton extends StatefulWidget {
   ///pressedOpacity, if non-null, must be in the range if 0.0 to 1.0
   const HelpButton({
-    Key? key,
+    super.key,
     this.color,
     this.disabledColor,
     this.onPressed,
@@ -21,8 +21,7 @@ class HelpButton extends StatefulWidget {
     this.semanticLabel,
     this.mouseCursor = SystemMouseCursors.basic,
   })  : assert(pressedOpacity == null ||
-            (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
-        super(key: key);
+            (pressedOpacity >= 0.0 && pressedOpacity <= 1.0));
 
   /// The color of the button's background.
   final Color? color;

--- a/lib/src/buttons/help_button.dart
+++ b/lib/src/buttons/help_button.dart
@@ -20,7 +20,7 @@ class HelpButton extends StatefulWidget {
     this.alignment = Alignment.center,
     this.semanticLabel,
     this.mouseCursor = SystemMouseCursors.basic,
-  })  : assert(pressedOpacity == null ||
+  }) : assert(pressedOpacity == null ||
             (pressedOpacity >= 0.0 && pressedOpacity <= 1.0));
 
   /// The color of the button's background.

--- a/lib/src/buttons/help_button.dart
+++ b/lib/src/buttons/help_button.dart
@@ -170,7 +170,7 @@ class HelpButtonState extends State<HelpButton>
       context,
     );
 
-    final Color? foregroundColor = widget.enabled
+    final Color foregroundColor = widget.enabled
         ? helpIconLuminance(backgroundColor, theme.brightness.isDark)
         : theme.brightness.isDark
             ? const Color.fromRGBO(255, 255, 255, 0.25)

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -25,7 +25,7 @@ class MacosIconButton extends StatefulWidget {
     ),
     this.padding,
     this.mouseCursor = SystemMouseCursors.basic,
-  })  : assert(pressedOpacity == null ||
+  }) : assert(pressedOpacity == null ||
             (pressedOpacity >= 0.0 && pressedOpacity <= 1.0));
 
   /// The widget to use as the icon.

--- a/lib/src/buttons/icon_button.dart
+++ b/lib/src/buttons/icon_button.dart
@@ -6,7 +6,7 @@ import 'package:macos_ui/src/library.dart';
 class MacosIconButton extends StatefulWidget {
   /// Builds a macOS-style icon button
   const MacosIconButton({
-    Key? key,
+    super.key,
     required this.icon,
     this.backgroundColor,
     this.disabledColor,
@@ -26,8 +26,7 @@ class MacosIconButton extends StatefulWidget {
     this.padding,
     this.mouseCursor = SystemMouseCursors.basic,
   })  : assert(pressedOpacity == null ||
-            (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
-        super(key: key);
+            (pressedOpacity >= 0.0 && pressedOpacity <= 1.0));
 
   /// The widget to use as the icon.
   ///

--- a/lib/src/buttons/popup_button.dart
+++ b/lib/src/buttons/popup_button.dart
@@ -24,13 +24,13 @@ typedef MacosPopupButtonBuilder = List<Widget> Function(BuildContext context);
 // The widget that is the button wrapping the menu items.
 class _MacosPopupMenuItemButton<T> extends StatefulWidget {
   const _MacosPopupMenuItemButton({
-    Key? key,
+    super.key,
     this.padding,
     required this.route,
     required this.buttonRect,
     required this.constraints,
     required this.itemIndex,
-  }) : super(key: key);
+  });
 
   final _MacosPopupRoute<T> route;
   final EdgeInsets? padding;
@@ -157,7 +157,7 @@ class _MacosPopupMenuItemButtonState<T>
 
 class _MacosPopupMenu<T> extends StatefulWidget {
   const _MacosPopupMenu({
-    Key? key,
+    super.key,
     this.padding,
     required this.route,
     required this.buttonRect,
@@ -165,7 +165,7 @@ class _MacosPopupMenu<T> extends StatefulWidget {
     this.popupColor,
     required this.hasTopItemsNotShown,
     required this.hasBottomItemsNotShown,
-  }) : super(key: key);
+  });
 
   final _MacosPopupRoute<T> route;
   final EdgeInsets? padding;
@@ -597,7 +597,7 @@ class _MacosPopupRoute<T> extends PopupRoute<_MacosPopupRouteResult<T>> {
 
 class _MacosPopupRoutePage<T> extends StatelessWidget {
   const _MacosPopupRoutePage({
-    Key? key,
+    super.key,
     required this.route,
     required this.constraints,
     this.items,
@@ -607,7 +607,7 @@ class _MacosPopupRoutePage<T> extends StatelessWidget {
     required this.capturedThemes,
     this.style,
     required this.popupColor,
-  }) : super(key: key);
+  });
 
   final _MacosPopupRoute<T> route;
   final BoxConstraints constraints;
@@ -674,10 +674,10 @@ class _MacosPopupRoutePage<T> extends StatelessWidget {
 // as closely as possible.
 class _MenuItem<T> extends SingleChildRenderObjectWidget {
   const _MenuItem({
-    Key? key,
+    super.key,
     required this.onLayout,
     required this.item,
-  }) : super(key: key, child: item);
+  }) : super(child: item);
 
   final ValueChanged<Size> onLayout;
   final MacosPopupMenuItem<T>? item;
@@ -716,10 +716,10 @@ class _MacosPopupMenuItemContainer extends StatelessWidget {
   ///
   /// The [child] argument is required.
   const _MacosPopupMenuItemContainer({
-    Key? key,
+    super.key,
     this.alignment = AlignmentDirectional.centerStart,
     required this.child,
-  }) : super(key: key);
+  });
 
   /// The widget below this widget in the tree.
   ///
@@ -757,13 +757,13 @@ class MacosPopupMenuItem<T> extends _MacosPopupMenuItemContainer {
   ///
   /// The [child] argument is required.
   const MacosPopupMenuItem({
-    Key? key,
+    super.key,
     this.onTap,
     this.value,
     this.enabled = true,
-    AlignmentGeometry alignment = AlignmentDirectional.centerStart,
-    required Widget child,
-  }) : super(key: key, alignment: alignment, child: child);
+    super.alignment,
+    required super.child,
+  });
 
   /// Called when the popup menu item is tapped.
   final VoidCallback? onTap;
@@ -828,7 +828,7 @@ class MacosPopupButton<T> extends StatefulWidget {
   /// popup when it is open. If it is null, the appropriate macOS canvas color
   /// will be used.
   MacosPopupButton({
-    Key? key,
+    super.key,
     required this.items,
     this.selectedItemBuilder,
     this.value,
@@ -856,8 +856,7 @@ class MacosPopupButton<T> extends StatefulWidget {
           'Either zero or 2 or more [MacosPopupMenuItem]s were detected '
           'with the same value',
         ),
-        assert(itemHeight == null || itemHeight >= _kMinInteractiveDimension),
-        super(key: key);
+        assert(itemHeight == null || itemHeight >= _kMinInteractiveDimension);
 
   /// The list of items the user can select.
   ///

--- a/lib/src/buttons/popup_button.dart
+++ b/lib/src/buttons/popup_button.dart
@@ -1028,16 +1028,16 @@ class _MacosPopupButtonState<T> extends State<MacosPopupButton<T>>
       ),
     };
     focusNode!.addListener(_handleFocusChanged);
-    final FocusManager focusManager = WidgetsBinding.instance!.focusManager;
+    final FocusManager focusManager = WidgetsBinding.instance.focusManager;
     _focusHighlightMode = focusManager.highlightMode;
     focusManager.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     _removeMacosPopupRoute();
-    WidgetsBinding.instance!.focusManager
+    WidgetsBinding.instance.focusManager
         .removeHighlightModeListener(_handleFocusHighlightModeChange);
     focusNode!.removeListener(_handleFocusChanged);
     _internalNode?.dispose();

--- a/lib/src/buttons/pulldown_button.dart
+++ b/lib/src/buttons/pulldown_button.dart
@@ -26,6 +26,7 @@ enum PulldownMenuAlignment {
 
 // The widget that is the button wrapping the menu items.
 class _MacosPulldownMenuItemButton extends StatefulWidget {
+  // ignore: use_super_parameters
   const _MacosPulldownMenuItemButton({
     Key? key,
     this.padding,
@@ -142,6 +143,7 @@ class _MacosPulldownMenuItemButtonState
 }
 
 class _MacosPulldownMenu extends StatefulWidget {
+  // ignore: use_super_parameters
   const _MacosPulldownMenu({
     Key? key,
     this.padding,
@@ -413,6 +415,7 @@ class _MacosPulldownRoute extends PopupRoute {
 }
 
 class _MacosPulldownRoutePage extends StatelessWidget {
+  // ignore: use_super_parameters
   const _MacosPulldownRoutePage({
     Key? key,
     required this.route,
@@ -472,6 +475,7 @@ class _MacosPulldownRoutePage extends StatelessWidget {
 // This widget enables _MacosPulldownRoute to look up the sizes of
 // each menu item.
 class _MenuItem extends SingleChildRenderObjectWidget {
+  // ignore: use_super_parameters
   const _MenuItem({
     Key? key,
     required this.onLayout,
@@ -511,7 +515,7 @@ class _RenderMenuItem extends RenderProxyBox {
 /// An entry in a menu created by a [MacosPulldownButton]. It can be either a
 /// [MacosPulldownMenuItem] or a [MacosPulldownMenuDivider].
 abstract class MacosPulldownMenuEntry extends Widget {
-  const MacosPulldownMenuEntry({Key? key}) : super(key: key);
+  const MacosPulldownMenuEntry({super.key});
 
   double get itemHeight;
 }
@@ -520,7 +524,7 @@ abstract class MacosPulldownMenuEntry extends Widget {
 class MacosPulldownMenuDivider extends StatelessWidget
     implements MacosPulldownMenuEntry {
   /// Creates a divider for a macOS-style pulldown menu.
-  const MacosPulldownMenuDivider({Key? key}) : super(key: key);
+  const MacosPulldownMenuDivider({super.key});
 
   @override
   double get itemHeight => _kMenuDividerHeight;
@@ -550,13 +554,13 @@ class MacosPulldownMenuItem extends StatelessWidget
     implements MacosPulldownMenuEntry {
   /// Creates an item for a macOS-style pulldown menu.
   const MacosPulldownMenuItem({
-    Key? key,
+    super.key,
     required this.title,
     this.onTap,
     this.enabled = true,
     this.alignment = AlignmentDirectional.centerStart,
     this.label,
-  }) : super(key: key);
+  });
 
   @override
   double get itemHeight => _kMenuItemHeight;
@@ -626,7 +630,7 @@ class MacosPulldownButton extends StatefulWidget {
   ///
   /// The [autofocus] argument must not be null.
   const MacosPulldownButton({
-    Key? key,
+    super.key,
     required this.items,
     this.title,
     this.disabledTitle,
@@ -641,8 +645,7 @@ class MacosPulldownButton extends StatefulWidget {
   })  : assert(itemHeight == null || itemHeight >= _kMenuItemHeight),
         assert(
             (title != null || icon != null) && !(title != null && icon != null),
-            "There should be either a title or an icon argument provided, and not both at at the same time."),
-        super(key: key);
+            "There should be either a title or an icon argument provided, and not both at at the same time.");
 
   /// The list of menu entries for the pull-down menu.
   ///

--- a/lib/src/buttons/pulldown_button.dart
+++ b/lib/src/buttons/pulldown_button.dart
@@ -763,16 +763,16 @@ class _MacosPulldownButtonState extends State<MacosPulldownButton>
       ),
     };
     focusNode!.addListener(_handleFocusChanged);
-    final FocusManager focusManager = WidgetsBinding.instance!.focusManager;
+    final FocusManager focusManager = WidgetsBinding.instance.focusManager;
     _focusHighlightMode = focusManager.highlightMode;
     focusManager.addHighlightModeListener(_handleFocusHighlightModeChange);
   }
 
   @override
   void dispose() {
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     _removeMacosPulldownRoute();
-    WidgetsBinding.instance!.focusManager
+    WidgetsBinding.instance.focusManager
         .removeHighlightModeListener(_handleFocusHighlightModeChange);
     focusNode!.removeListener(_handleFocusChanged);
     _internalNode?.dispose();

--- a/lib/src/buttons/push_button.dart
+++ b/lib/src/buttons/push_button.dart
@@ -25,7 +25,7 @@ const BorderRadius _kLargeButtonRadius = BorderRadius.all(Radius.circular(7.0));
 /// A macOS-style button.
 class PushButton extends StatefulWidget {
   const PushButton({
-    Key? key,
+    super.key,
     required this.child,
     required this.buttonSize,
     this.padding,
@@ -39,8 +39,7 @@ class PushButton extends StatefulWidget {
     this.mouseCursor = SystemMouseCursors.basic,
     this.isSecondary,
   })  : assert(pressedOpacity == null ||
-            (pressedOpacity >= 0.0 && pressedOpacity <= 1.0)),
-        super(key: key);
+            (pressedOpacity >= 0.0 && pressedOpacity <= 1.0));
 
   /// The widget below this widget in the tree.
   ///

--- a/lib/src/buttons/push_button.dart
+++ b/lib/src/buttons/push_button.dart
@@ -38,7 +38,7 @@ class PushButton extends StatefulWidget {
     this.semanticLabel,
     this.mouseCursor = SystemMouseCursors.basic,
     this.isSecondary,
-  })  : assert(pressedOpacity == null ||
+  }) : assert(pressedOpacity == null ||
             (pressedOpacity >= 0.0 && pressedOpacity <= 1.0));
 
   /// The widget below this widget in the tree.

--- a/lib/src/buttons/radio_button.dart
+++ b/lib/src/buttons/radio_button.dart
@@ -23,7 +23,7 @@ class MacosRadioButton<T> extends StatelessWidget {
     this.offColor = CupertinoColors.tertiaryLabel,
     this.innerColor,
     this.semanticLabel,
-  })  : assert(size >= 0);
+  }) : assert(size >= 0);
 
   /// Whether the button is checked or not
   final T value;

--- a/lib/src/buttons/radio_button.dart
+++ b/lib/src/buttons/radio_button.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:macos_ui/macos_ui.dart';
 import 'package:macos_ui/src/library.dart';
@@ -15,7 +14,7 @@ class MacosRadioButton<T> extends StatelessWidget {
   ///
   /// [size] must be non-negative
   const MacosRadioButton({
-    Key? key,
+    super.key,
     required this.value,
     required this.groupValue,
     required this.onChanged,
@@ -24,8 +23,7 @@ class MacosRadioButton<T> extends StatelessWidget {
     this.offColor = CupertinoColors.tertiaryLabel,
     this.innerColor,
     this.semanticLabel,
-  })  : assert(size >= 0),
-        super(key: key);
+  })  : assert(size >= 0);
 
   /// Whether the button is checked or not
   final T value;

--- a/lib/src/buttons/switch.dart
+++ b/lib/src/buttons/switch.dart
@@ -9,14 +9,14 @@ import 'package:macos_ui/src/library.dart';
 /// accent color is visible and off when the switch appears colorless.
 class MacosSwitch extends StatelessWidget {
   const MacosSwitch({
-    Key? key,
+    super.key,
     required this.value,
     required this.onChanged,
     this.dragStartBehavior = DragStartBehavior.start,
     this.activeColor,
     this.trackColor,
     this.semanticLabel,
-  }) : super(key: key);
+  });
 
   /// Whether this switch is on or off.
   ///

--- a/lib/src/buttons/toolbar/toolbar_icon_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_icon_button.dart
@@ -53,7 +53,7 @@ class ToolBarIconButton extends ToolbarItem {
   Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
     final brightness = MacosTheme.of(context).brightness;
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
-      Widget _iconButton = MacosIconButton(
+      Widget iconButton = MacosIconButton(
         disabledColor: Colors.transparent,
         icon: MacosIconTheme(
           data: MacosTheme.of(context).iconTheme.copyWith(
@@ -76,11 +76,11 @@ class ToolBarIconButton extends ToolbarItem {
       );
 
       if (showLabel) {
-        _iconButton = Padding(
+        iconButton = Padding(
           padding: const EdgeInsets.fromLTRB(6.0, 6.0, 6.0, 0.0),
           child: Column(
             children: [
-              _iconButton,
+              iconButton,
               Padding(
                 padding: const EdgeInsets.only(top: 4.0),
                 child: Text(
@@ -97,12 +97,12 @@ class ToolBarIconButton extends ToolbarItem {
       }
 
       if (tooltipMessage != null) {
-        _iconButton = MacosTooltip(
+        iconButton = MacosTooltip(
           message: tooltipMessage!,
-          child: _iconButton,
+          child: iconButton,
         );
       }
-      return _iconButton;
+      return iconButton;
     } else {
       return ToolbarOverflowMenuItem(
         label: label,

--- a/lib/src/buttons/toolbar/toolbar_icon_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_icon_button.dart
@@ -15,13 +15,13 @@ class ToolBarIconButton extends ToolbarItem {
   /// "system control" toolbar item from Apple's design guidelines. If true,
   /// it replicates the "image button" toolbar item.
   const ToolBarIconButton({
-    Key? key,
+    super.key,
     required this.label,
     required this.icon,
     this.onPressed,
     required this.showLabel,
     this.tooltipMessage,
-  }) : super(key: key);
+  });
 
   /// The label that describes this button's action.
   ///

--- a/lib/src/buttons/toolbar/toolbar_overflow_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_overflow_button.dart
@@ -9,10 +9,10 @@ class ToolbarOverflowButton extends StatelessWidget {
   /// When clicked, it opens a [ToolbarOverflowMenu] holding all overflowed
   /// actions in a simplified menu.
   const ToolbarOverflowButton({
-    Key? key,
+    super.key,
     required this.overflowContentBuilder,
     this.isDense = false,
-  }) : super(key: key);
+  });
 
   /// A function that builds the content of the overflowed actions menu.
   final WidgetBuilder overflowContentBuilder;

--- a/lib/src/buttons/toolbar/toolbar_overflow_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_overflow_button.dart
@@ -25,6 +25,11 @@ class ToolbarOverflowButton extends StatelessWidget {
     final popupKey = GlobalKey<ToolbarPopupState>();
     return ToolbarPopup(
       key: popupKey,
+      content: overflowContentBuilder,
+      verticalOffset: 8.0,
+      horizontalOffset: 10.0,
+      position: ToolbarPopupPosition.below,
+      placement: ToolbarPopupPlacement.end,
       child: ToolBarIconButton(
         label: "",
         icon: const MacosIcon(
@@ -35,11 +40,6 @@ class ToolbarOverflowButton extends StatelessWidget {
         },
         showLabel: isDense,
       ).build(context, ToolbarItemDisplayMode.inToolbar),
-      content: overflowContentBuilder,
-      verticalOffset: 8.0,
-      horizontalOffset: 10.0,
-      position: ToolbarPopupPosition.below,
-      placement: ToolbarPopupPlacement.end,
     );
   }
 }

--- a/lib/src/buttons/toolbar/toolbar_pulldown_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_pulldown_button.dart
@@ -53,7 +53,7 @@ class ToolBarPullDownButton extends ToolbarItem {
     final brightness = MacosTheme.of(context).brightness;
 
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
-      Widget _pulldownButton = Padding(
+      Widget pulldownButton = Padding(
         padding: const EdgeInsets.symmetric(vertical: 6.0),
         child: MacosPulldownButtonTheme(
           data: MacosPulldownButtonTheme.of(context).copyWith(
@@ -70,12 +70,12 @@ class ToolBarPullDownButton extends ToolbarItem {
       );
 
       if (tooltipMessage != null) {
-        _pulldownButton = MacosTooltip(
+        pulldownButton = MacosTooltip(
           message: tooltipMessage!,
-          child: _pulldownButton,
+          child: pulldownButton,
         );
       }
-      return _pulldownButton;
+      return pulldownButton;
     } else {
       // We should show a submenu for the pulldown button items.
       final subMenuKey = GlobalKey<ToolbarPopupState>();

--- a/lib/src/buttons/toolbar/toolbar_pulldown_button.dart
+++ b/lib/src/buttons/toolbar/toolbar_pulldown_button.dart
@@ -12,12 +12,12 @@ class ToolBarPullDownButton extends ToolbarItem {
   /// [ToolbarOverflowMenuItem], that opens a subsequent submenu with the
   /// pulldown items.
   const ToolBarPullDownButton({
-    Key? key,
+    super.key,
     required this.label,
     required this.icon,
     required this.items,
     this.tooltipMessage,
-  }) : super(key: key);
+  });
 
   /// The label that describes this button's action.
   ///

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -34,7 +34,7 @@ const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 class MacosAlertDialog extends StatelessWidget {
   /// Builds a macOS-style Alert Dialog
   const MacosAlertDialog({
-    Key? key,
+    super.key,
     required this.appIcon,
     required this.title,
     required this.message,
@@ -42,7 +42,7 @@ class MacosAlertDialog extends StatelessWidget {
     this.secondaryButton,
     this.horizontalActions = true,
     this.suppress,
-  }) : super(key: key);
+  });
 
   /// This should be your application's icon.
   ///
@@ -277,12 +277,11 @@ class _MacosAlertDialogRoute<T> extends PopupRoute<T> {
     bool barrierDismissible = false,
     Color? barrierColor = const Color(0x80000000),
     String? barrierLabel,
-    RouteSettings? settings,
+    super.settings,
   })  : _pageBuilder = pageBuilder,
         _barrierDismissible = barrierDismissible,
         _barrierLabel = barrierLabel,
-        _barrierColor = barrierColor,
-        super(settings: settings);
+        _barrierColor = barrierColor;
 
   final RoutePageBuilder _pageBuilder;
 

--- a/lib/src/fields/search_field.dart
+++ b/lib/src/fields/search_field.dart
@@ -31,7 +31,7 @@ class MacosSearchField<T> extends StatefulWidget {
   /// You can also set a callback action individually for each
   /// [SearchResultItem] via the [onSelected] property.
   const MacosSearchField({
-    Key? key,
+    super.key,
     this.results,
     this.onResultSelected,
     this.maxResultsToShow = 5,
@@ -60,7 +60,7 @@ class MacosSearchField<T> extends StatefulWidget {
     this.inputFormatters,
     this.enabled = true,
     this.onTap,
-  }) : super(key: key);
+  });
 
   /// List of results for the searchfield.
   ///
@@ -480,6 +480,7 @@ class SearchResultItem {
 /// A wrapper around the [SearchResultItem] to provide it with the
 /// appropriate mouse and hover detection.
 class _SearchResultItemButton extends StatefulWidget {
+  // ignore: use_super_parameters
   const _SearchResultItemButton({
     Key? key,
     this.onPressed,

--- a/lib/src/fields/search_field.dart
+++ b/lib/src/fields/search_field.dart
@@ -245,7 +245,7 @@ class _MacosSearchFieldState<T> extends State<MacosSearchField<T>> {
         _overlayEntry.remove();
       }
     });
-    WidgetsBinding.instance!.addPostFrameCallback((_) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       suggestionStream.sink.add(null);
       suggestionStream.sink.add(widget.results);
     });

--- a/lib/src/fields/search_field.dart
+++ b/lib/src/fields/search_field.dart
@@ -209,7 +209,7 @@ class MacosSearchField<T> extends StatefulWidget {
   final GestureTapCallback? onTap;
 
   @override
-  _MacosSearchFieldState<T> createState() => _MacosSearchFieldState();
+  State<MacosSearchField<T>> createState() => _MacosSearchFieldState();
 }
 
 class _MacosSearchFieldState<T> extends State<MacosSearchField<T>> {

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -231,7 +231,7 @@ class MacosTextField extends StatefulWidget {
   ///  * [maxLength], which discusses the precise meaning of "number of
   ///    characters" and how it may differ from the intuitive meaning.
   const MacosTextField({
-    Key? key,
+    super.key,
     this.controller,
     this.focusNode,
     this.decoration = kDefaultRoundedBorderDecoration,
@@ -326,8 +326,7 @@ class MacosTextField extends StatefulWidget {
                     cut: true,
                     selectAll: true,
                     paste: true,
-                  )),
-        super(key: key);
+                  ));
 
   /// Creates a borderless macOS-style text field.
   ///
@@ -366,7 +365,7 @@ class MacosTextField extends StatefulWidget {
   ///  * [maxLength], which discusses the precise meaning of "number of
   ///    characters" and how it may differ from the intuitive meaning.
   const MacosTextField.borderless({
-    Key? key,
+    super.key,
     this.controller,
     this.focusNode,
     this.decoration,
@@ -458,8 +457,7 @@ class MacosTextField extends StatefulWidget {
                     cut: true,
                     selectAll: true,
                     paste: true,
-                  )),
-        super(key: key);
+                  ));
 
   /// Controls the text being edited.
   ///

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -731,7 +731,7 @@ class MacosTextField extends StatefulWidget {
   final String? restorationId;
 
   @override
-  _MacosTextFieldState createState() => _MacosTextFieldState();
+  State<MacosTextField> createState() => _MacosTextFieldState();
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/icon/macos_icon.dart
+++ b/lib/src/icon/macos_icon.dart
@@ -10,12 +10,12 @@ class MacosIcon extends StatelessWidget {
   /// [MacosIconTheme].
   const MacosIcon(
     this.icon, {
-    Key? key,
+    super.key,
     this.size,
     this.color,
     this.semanticLabel,
     this.textDirection,
-  }) : super(key: key);
+  });
 
   /// The icon to display. The available icons are described in [Icons]
   /// and [CupertinoIcons].

--- a/lib/src/indicators/capacity_indicators.dart
+++ b/lib/src/indicators/capacity_indicators.dart
@@ -34,7 +34,7 @@ class CapacityIndicator extends StatelessWidget {
   ///
   /// [value] must be in range of 0 to 100.
   const CapacityIndicator({
-    Key? key,
+    super.key,
     required this.value,
     this.onChanged,
     this.discrete = false,
@@ -43,8 +43,7 @@ class CapacityIndicator extends StatelessWidget {
     this.borderColor = CupertinoColors.tertiaryLabel,
     this.backgroundColor = CupertinoColors.tertiarySystemGroupedBackground,
     this.semanticLabel,
-  })  : assert(value >= 0 && value <= 100),
-        super(key: key);
+  })  : assert(value >= 0 && value <= 100);
 
   /// The current value of the indicator. Must be in the range of 0 to 100.
   final double value;
@@ -168,13 +167,12 @@ class CapacityIndicatorCell extends StatelessWidget {
   ///
   /// [value] must be in the range of 0 to 100
   const CapacityIndicatorCell({
-    Key? key,
+    super.key,
     this.value = 100,
     this.color = CupertinoColors.systemGreen,
     this.borderColor = CupertinoColors.tertiaryLabel,
     this.backgroundColor = CupertinoColors.tertiarySystemGroupedBackground,
-  })  : assert(value >= 0 && value <= 100),
-        super(key: key);
+  })  : assert(value >= 0 && value <= 100);
 
   final Color color;
   final Color backgroundColor;

--- a/lib/src/indicators/capacity_indicators.dart
+++ b/lib/src/indicators/capacity_indicators.dart
@@ -43,7 +43,7 @@ class CapacityIndicator extends StatelessWidget {
     this.borderColor = CupertinoColors.tertiaryLabel,
     this.backgroundColor = CupertinoColors.tertiarySystemGroupedBackground,
     this.semanticLabel,
-  })  : assert(value >= 0 && value <= 100);
+  }) : assert(value >= 0 && value <= 100);
 
   /// The current value of the indicator. Must be in the range of 0 to 100.
   final double value;
@@ -172,7 +172,7 @@ class CapacityIndicatorCell extends StatelessWidget {
     this.color = CupertinoColors.systemGreen,
     this.borderColor = CupertinoColors.tertiaryLabel,
     this.backgroundColor = CupertinoColors.tertiarySystemGroupedBackground,
-  })  : assert(value >= 0 && value <= 100);
+  }) : assert(value >= 0 && value <= 100);
 
   final Color color;
   final Color backgroundColor;

--- a/lib/src/indicators/progress_indicators.dart
+++ b/lib/src/indicators/progress_indicators.dart
@@ -14,15 +14,14 @@ class ProgressCircle extends StatelessWidget {
   ///
   /// [value] must be in the range of 0 and 100
   const ProgressCircle({
-    Key? key,
+    super.key,
     this.value,
     this.radius = 10,
     this.innerColor,
     this.borderColor,
     this.semanticLabel,
   })  : assert(value == null || value >= 0 && value <= 100),
-        assert(radius >= 0),
-        super(key: key);
+        assert(radius >= 0);
 
   /// The value of the progress circle. If non-null, this has to
   /// be non-negative and less the 100. If null, the progress circle
@@ -158,15 +157,14 @@ class ProgressBar extends StatelessWidget {
   ///
   /// [value] must be in the range of 0 and 100
   const ProgressBar({
-    Key? key,
+    super.key,
     this.height = 4.5,
     required this.value,
     this.trackColor,
     this.backgroundColor,
     this.semanticLabel,
   })  : assert(value >= 0 && value <= 100),
-        assert(height >= 0),
-        super(key: key);
+        assert(height >= 0);
 
   /// The value of the progress bar. If non-null, this has to
   /// be non-negative and less the 100. If null, the progress bar

--- a/lib/src/indicators/rating_indicator.dart
+++ b/lib/src/indicators/rating_indicator.dart
@@ -19,7 +19,7 @@ class RatingIndicator extends StatelessWidget {
   ///
   /// [value] must be in range of 0 to [amount]
   const RatingIndicator({
-    Key? key,
+    super.key,
     required this.value,
     this.amount = 5,
     this.ratedIcon = CupertinoIcons.star_fill,
@@ -30,8 +30,7 @@ class RatingIndicator extends StatelessWidget {
     this.semanticLabel,
   })  : assert(iconSize >= 0),
         assert(amount > 0),
-        assert(value >= 0 && value <= amount),
-        super(key: key);
+        assert(value >= 0 && value <= amount);
 
   /// The icon used when the star is rated. [CupertinoIcons.star_fill]
   /// is used by default. If you must replace the star with a custom

--- a/lib/src/indicators/relevance_indicator.dart
+++ b/lib/src/indicators/relevance_indicator.dart
@@ -14,7 +14,7 @@ class RelevanceIndicator extends StatelessWidget {
   ///
   /// [barHeight] and [barWidth] must be non-null
   const RelevanceIndicator({
-    Key? key,
+    super.key,
     required this.value,
     this.amount = 20,
     this.barHeight = 20,
@@ -25,8 +25,7 @@ class RelevanceIndicator extends StatelessWidget {
   })  : assert(value >= 0 && value <= amount),
         assert(amount > 0),
         assert(barHeight >= 0),
-        assert(barWidth >= 0),
-        super(key: key);
+        assert(barWidth >= 0);
 
   /// The current value of the indicator. It must be in the range
   /// of 0 to [amount]

--- a/lib/src/indicators/scrollbar.dart
+++ b/lib/src/indicators/scrollbar.dart
@@ -40,7 +40,7 @@ class MacosScrollbar extends StatelessWidget {
   /// except for when executing on [TargetPlatform.android], which will render the
   /// thumb without a radius.
   const MacosScrollbar({
-    Key? key,
+    super.key,
     required this.child,
     this.controller,
     this.isAlwaysShown,
@@ -49,7 +49,7 @@ class MacosScrollbar extends StatelessWidget {
     this.radius,
     this.notificationPredicate,
     this.interactive,
-  }) : super(key: key);
+  });
 
   /// {@macro flutter.widgets.Scrollbar.child}
   final Widget child;

--- a/lib/src/indicators/scrollbar.dart
+++ b/lib/src/indicators/scrollbar.dart
@@ -12,14 +12,14 @@ import 'package:macos_ui/src/library.dart';
 /// The color of the Scrollbar will change when dragged. A hover animation is
 /// also triggered when used on web and desktop platforms. A scrollbar track
 /// can also been drawn when triggered by a hover event, which is controlled by
-/// [showTrackOnHover]. The thickness of the track and scrollbar thumb will
+/// [trackVisibility]. The thickness of the track and scrollbar thumb will
 /// become larger when hovering, unless overridden by [hoverThickness].
 ///
 /// See also:
 ///
 ///  * [RawScrollbar], a basic scrollbar that fades in and out, extended
 ///    by this class to add more animations and behaviors.
-///  * [ScrollbarTheme], which configures the Scrollbar's appearance.
+///  * [MacosScrollbarTheme], which configures the Scrollbar's appearance.
 ///  * [m.Scrollbar], a Material style scrollbar.
 ///  * [CupertinoScrollbar], an iOS style scrollbar.
 ///  * [ListView], which displays a linear, scrollable list of children.
@@ -44,8 +44,7 @@ class MacosScrollbar extends StatelessWidget {
     required this.child,
     this.controller,
     this.isAlwaysShown,
-    this.showTrackOnHover,
-    this.hoverThickness,
+    this.trackVisibility,
     this.thickness,
     this.radius,
     this.notificationPredicate,
@@ -61,20 +60,12 @@ class MacosScrollbar extends StatelessWidget {
   /// {@macro flutter.widgets.Scrollbar.isAlwaysShown}
   final bool? isAlwaysShown;
 
-  /// Controls if the track will show on hover and remain, including during drag.
+  /// Controls if the track will always be visible or not.
   ///
-  /// If this property is null, then [ScrollbarThemeData.showTrackOnHover] of
+  /// If this property is null, then [MacosScrollbarThemeData.showTrackOnHover] of
   /// [MacosThemeData.scrollbarTheme] is used. If that is also null, the default value
   /// is false.
-  final bool? showTrackOnHover;
-
-  /// The thickness of the scrollbar when a hover state is active and
-  /// [showTrackOnHover] is true.
-  ///
-  /// If this property is null, then [ScrollbarThemeData.thickness] of
-  /// [MacosThemeData.scrollbarTheme] is used to resolve a thickness. If that is also
-  /// null, the default value is 12.0 pixels.
-  final double? hoverThickness;
+  final bool? trackVisibility;
 
   /// The thickness of the scrollbar in the cross axis of the scrollable.
   ///
@@ -101,14 +92,16 @@ class MacosScrollbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMacosTheme(context));
-    final theme = ScrollbarTheme.of(context);
+    final theme = MacosScrollbarTheme.of(context);
     return m.ScrollbarTheme(
       data: m.ScrollbarThemeData(
         crossAxisMargin: theme.crossAxisMargin,
         mainAxisMargin: theme.mainAxisMargin,
         interactive: theme.interactive,
-        isAlwaysShown: theme.isAlwaysShown,
-        showTrackOnHover: theme.showTrackOnHover,
+        thumbVisibility: m.MaterialStateProperty.resolveWith((states) => true),
+        trackVisibility: m.MaterialStateProperty.resolveWith((states) {
+          return trackVisibility;
+        }),
         minThumbLength: theme.minThumbLength,
         radius: theme.radius,
         thickness: m.MaterialStateProperty.resolveWith((states) {
@@ -141,9 +134,8 @@ class MacosScrollbar extends StatelessWidget {
       child: m.Scrollbar(
         child: child,
         controller: controller,
-        isAlwaysShown: isAlwaysShown,
-        showTrackOnHover: showTrackOnHover,
-        hoverThickness: hoverThickness,
+        thumbVisibility: isAlwaysShown,
+        trackVisibility: trackVisibility,
         thickness: thickness,
         radius: radius,
         interactive: interactive,

--- a/lib/src/indicators/scrollbar.dart
+++ b/lib/src/indicators/scrollbar.dart
@@ -132,7 +132,6 @@ class MacosScrollbar extends StatelessWidget {
         }),
       ),
       child: m.Scrollbar(
-        child: child,
         controller: controller,
         thumbVisibility: isAlwaysShown,
         trackVisibility: trackVisibility,
@@ -140,6 +139,7 @@ class MacosScrollbar extends StatelessWidget {
         radius: radius,
         interactive: interactive,
         notificationPredicate: notificationPredicate,
+        child: child,
       ),
     );
   }

--- a/lib/src/labels/label.dart
+++ b/lib/src/labels/label.dart
@@ -9,12 +9,12 @@ import 'package:macos_ui/src/library.dart';
 class Label extends StatelessWidget {
   /// Creates a label.
   const Label({
-    Key? key,
+    super.key,
     this.icon,
     required this.text,
     this.child,
     this.yAlignment = CrossAxisAlignment.start,
-  }) : super(key: key);
+  });
 
   /// The icon used by the label. If non-null, it's rendered horizontally
   /// before [text].

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -24,12 +24,12 @@ class MacosTooltip extends StatefulWidget {
   /// Wrap any widget in a [MacosTooltip] to show a message on mouse hover or
   /// long press event
   const MacosTooltip({
-    Key? key,
+    super.key,
     required this.message,
     this.child,
     this.excludeFromSemantics = false,
     this.useMousePosition = true,
-  }) : super(key: key);
+  });
 
   /// The text to display in the tooltip.
   final String message;
@@ -346,6 +346,7 @@ class _TooltipPositionDelegate extends SingleChildLayoutDelegate {
 }
 
 class _TooltipOverlay extends StatelessWidget {
+  // ignore: use_super_parameters
   const _TooltipOverlay({
     Key? key,
     required this.message,

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -85,18 +85,18 @@ class _MacosTooltipState extends State<MacosTooltip>
   @override
   void initState() {
     super.initState();
-    _mouseIsConnected = RendererBinding.instance!.mouseTracker.mouseIsConnected;
+    _mouseIsConnected = RendererBinding.instance.mouseTracker.mouseIsConnected;
     _controller = AnimationController(
       duration: _fadeInDuration,
       reverseDuration: _fadeOutDuration,
       vsync: this,
     )..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
-    RendererBinding.instance!.mouseTracker
+    RendererBinding.instance.mouseTracker
         .addListener(_handleMouseTrackerChange);
     // Listen to global pointer events so that we can hide a tooltip immediately
     // if some other control is clicked on.
-    GestureBinding.instance!.pointerRouter.addGlobalRoute(_handlePointerEvent);
+    GestureBinding.instance.pointerRouter.addGlobalRoute(_handlePointerEvent);
   }
 
   // Forces a rebuild if a mouse has been added or removed.
@@ -105,7 +105,7 @@ class _MacosTooltipState extends State<MacosTooltip>
       return;
     }
     final bool mouseIsConnected =
-        RendererBinding.instance!.mouseTracker.mouseIsConnected;
+        RendererBinding.instance.mouseTracker.mouseIsConnected;
     if (mouseIsConnected != _mouseIsConnected) {
       setState(() {
         _mouseIsConnected = mouseIsConnected;
@@ -238,9 +238,9 @@ class _MacosTooltipState extends State<MacosTooltip>
 
   @override
   void dispose() {
-    GestureBinding.instance!.pointerRouter
+    GestureBinding.instance.pointerRouter
         .removeGlobalRoute(_handlePointerEvent);
-    RendererBinding.instance!.mouseTracker
+    RendererBinding.instance.mouseTracker
         .removeListener(_handleMouseTrackerChange);
     if (_entry != null) _removeEntry();
     _controller.dispose();

--- a/lib/src/labels/tooltip.dart
+++ b/lib/src/labels/tooltip.dart
@@ -56,7 +56,7 @@ class MacosTooltip extends StatefulWidget {
   final bool useMousePosition;
 
   @override
-  _MacosTooltipState createState() => _MacosTooltipState();
+  State<MacosTooltip> createState() => _MacosTooltipState();
 }
 
 class _MacosTooltipState extends State<MacosTooltip>

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -6,7 +6,7 @@ import 'package:macos_ui/src/library.dart';
 class MacosListTile extends StatelessWidget {
   /// Builds a [MacosListTile].
   const MacosListTile({
-    Key? key,
+    super.key,
     this.leading,
     required this.title,
     this.subtitle,
@@ -14,7 +14,7 @@ class MacosListTile extends StatelessWidget {
     this.onClick,
     this.onLongPress,
     this.mouseCursor = MouseCursor.defer,
-  }) : super(key: key);
+  });
 
   /// A widget to display before the [title].
   final Widget? leading;

--- a/lib/src/layout/resizable_pane.dart
+++ b/lib/src/layout/resizable_pane.dart
@@ -20,7 +20,7 @@ class ResizablePane extends StatefulWidget {
   ///
   /// The [startWidth] is the initial width.
   const ResizablePane({
-    Key? key,
+    super.key,
     required this.builder,
     this.decoration,
     this.maxWidth = 500.0,
@@ -36,8 +36,7 @@ class ResizablePane extends StatefulWidget {
         assert(
           (startWidth >= minWidth) && (startWidth <= maxWidth),
           'startWidth must not be less than minWidth or more than maxWidth',
-        ),
-        super(key: key);
+        );
 
   /// The builder that creates a child to display in this widget, which will
   /// use the provided [_scrollController] to enable the scrollbar to work.

--- a/lib/src/layout/resizable_pane.dart
+++ b/lib/src/layout/resizable_pane.dart
@@ -74,7 +74,7 @@ class ResizablePane extends StatefulWidget {
   final double? windowBreakpoint;
 
   @override
-  _ResizablePaneState createState() => _ResizablePaneState();
+  State<ResizablePane> createState() => _ResizablePaneState();
 }
 
 class _ResizablePaneState extends State<ResizablePane> {
@@ -89,9 +89,9 @@ class _ResizablePaneState extends State<ResizablePane> {
   bool get _resizeOnRight => widget.resizableSide == ResizableSide.right;
 
   BoxDecoration get _decoration {
-    final _borderSide = BorderSide(color: _dividerColor);
-    final right = Border(right: _borderSide);
-    final left = Border(left: _borderSide);
+    final borderSide = BorderSide(color: _dividerColor);
+    final right = Border(right: borderSide);
+    final left = Border(left: borderSide);
     return BoxDecoration(border: _resizeOnRight ? right : left).copyWith(
       color: widget.decoration?.color,
       border: widget.decoration?.border,
@@ -175,17 +175,17 @@ class _ResizablePaneState extends State<ResizablePane> {
   @override
   Widget build(BuildContext context) {
     final media = MediaQuery.of(context);
-    final _maxHeight = media.size.height;
-    final _maxWidth = media.size.width;
+    final maxHeight = media.size.height;
+    final maxWidth = media.size.width;
 
     if (widget.windowBreakpoint != null &&
-        _maxWidth <= widget.windowBreakpoint!) {
+        maxWidth <= widget.windowBreakpoint!) {
       return const SizedBox.shrink();
     }
 
     return Container(
       width: _width,
-      height: _maxHeight,
+      height: maxHeight,
       decoration: _decoration,
       constraints: BoxConstraints(
         maxWidth: widget.maxWidth,
@@ -205,14 +205,14 @@ class _ResizablePaneState extends State<ResizablePane> {
             Positioned(
               left: 0,
               width: 5,
-              height: _maxHeight,
+              height: maxHeight,
               child: _resizeArea,
             ),
           if (widget.isResizable && _resizeOnRight)
             Positioned(
               right: 0,
               width: 5,
-              height: _maxHeight,
+              height: maxHeight,
               child: _resizeArea,
             ),
         ],

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -38,7 +38,7 @@ class MacosScaffold extends StatefulWidget {
   final ToolBar? toolBar;
 
   @override
-  _MacosScaffoldState createState() => _MacosScaffoldState();
+  State<MacosScaffold> createState() => _MacosScaffoldState();
 }
 
 class _MacosScaffoldState extends State<MacosScaffold> {
@@ -93,10 +93,10 @@ class _MacosScaffoldState extends State<MacosScaffold> {
               width: width,
               height: height,
               child: MediaQuery(
-                child: _ScaffoldBody(children: children),
                 data: mediaQuery.copyWith(
                   padding: EdgeInsets.only(top: topPadding),
                 ),
+                child: _ScaffoldBody(children: children),
               ),
             ),
 
@@ -179,11 +179,11 @@ class _RenderScaffoldBody extends RenderBox
     RenderBox? child = firstChild;
     double sum = 0;
 
-    final _children = getChildrenAsList();
+    final children = getChildrenAsList();
     if (contentAreaIndex != null) {
-      _children.removeAt(contentAreaIndex!);
+      children.removeAt(contentAreaIndex!);
     }
-    for (var child in _children) {
+    for (var child in children) {
       child.layout(const BoxConstraints.tightFor(), parentUsesSize: true);
       sum += child.size.width;
     }

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -19,11 +19,11 @@ class MacosScaffold extends StatefulWidget {
   /// The [children] can only include one [ContentArea], but can include
   /// multiple [ResizablePane] widgets.
   const MacosScaffold({
-    Key? key,
+    super.key,
     this.children = const <Widget>[],
     this.toolBar,
     this.backgroundColor,
-  }) : super(key: key);
+  });
 
   /// Specifies the background color for the Scaffold.
   ///
@@ -116,8 +116,8 @@ class _MacosScaffoldState extends State<MacosScaffold> {
 
 class _ScaffoldBody extends MultiChildRenderObjectWidget {
   _ScaffoldBody({
-    List<Widget> children = const <Widget>[],
-  }) : super(children: children);
+    super.children,
+  });
 
   @override
   RenderObject createRenderObject(BuildContext context) {

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -24,7 +24,7 @@ class SidebarItems extends StatelessWidget {
     this.unselectedColor,
     this.shape,
     this.cursor = SystemMouseCursors.basic,
-  })  : assert(currentIndex >= 0);
+  }) : assert(currentIndex >= 0);
 
   /// The [SidebarItem]s used by the sidebar. If no items are provided,
   /// the sidebar is not rendered.

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -15,7 +15,7 @@ const ShapeBorder _defaultShape = RoundedRectangleBorder(
 class SidebarItems extends StatelessWidget {
   /// Creates a scrollable widget that renders [SidebarItem]s.
   const SidebarItems({
-    Key? key,
+    super.key,
     required this.currentIndex,
     required this.onChanged,
     required this.items,
@@ -24,8 +24,7 @@ class SidebarItems extends StatelessWidget {
     this.unselectedColor,
     this.shape,
     this.cursor = SystemMouseCursors.basic,
-  })  : assert(currentIndex >= 0),
-        super(key: key);
+  })  : assert(currentIndex >= 0);
 
   /// The [SidebarItem]s used by the sidebar. If no items are provided,
   /// the sidebar is not rendered.
@@ -120,13 +119,14 @@ class SidebarItems extends StatelessWidget {
 }
 
 class _SidebarItemsConfiguration extends InheritedWidget {
+  // ignore: use_super_parameters
   const _SidebarItemsConfiguration({
     Key? key,
-    required Widget child,
+    required super.child,
     this.selectedColor = MacosColors.transparent,
     this.unselectedColor = MacosColors.transparent,
     this.shape = _defaultShape,
-  }) : super(key: key, child: child);
+  }) : super(key: key);
 
   final Color selectedColor;
   final Color unselectedColor;
@@ -146,6 +146,7 @@ class _SidebarItemsConfiguration extends InheritedWidget {
 /// A macOS style navigation-list item intended for use in a [Sidebar]
 class _SidebarItem extends StatelessWidget {
   /// Builds a [_SidebarItem].
+  // ignore: use_super_parameters
   const _SidebarItem({
     Key? key,
     required this.item,
@@ -255,6 +256,7 @@ class _SidebarItem extends StatelessWidget {
 }
 
 class _DisclosureSidebarItem extends StatefulWidget {
+  // ignore: use_super_parameters
   _DisclosureSidebarItem({
     Key? key,
     required this.item,

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -380,7 +380,9 @@ class __DisclosureSidebarItemState extends State<_DisclosureSidebarItem>
     final bool closed = !_isExpanded && _controller.isDismissed;
 
     final Widget result = Offstage(
+      offstage: closed,
       child: TickerMode(
+        enabled: !closed,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: widget.item.disclosureItems!.map((item) {
@@ -399,9 +401,7 @@ class __DisclosureSidebarItemState extends State<_DisclosureSidebarItem>
             );
           }).toList(),
         ),
-        enabled: !closed,
       ),
-      offstage: closed,
     );
 
     return AnimatedBuilder(

--- a/lib/src/layout/title_bar.dart
+++ b/lib/src/layout/title_bar.dart
@@ -75,10 +75,10 @@ class TitleBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final MacosThemeData theme = MacosTheme.of(context);
 
+    // ignore: no_leading_underscores_for_local_identifiers
     Widget? _title = title;
     if (_title != null) {
       _title = DefaultTextStyle(
-        child: _title,
         style: theme.typography.headline.copyWith(
           fontSize: 10,
           fontWeight: FontWeight.w600,
@@ -86,6 +86,7 @@ class TitleBar extends StatelessWidget {
               ? const Color(0xFFEAEAEA)
               : const Color(0xFF4D4D4D),
         ),
+        child: _title,
       );
     }
 
@@ -119,7 +120,7 @@ class TitleBar extends StatelessWidget {
               gradient: decoration?.gradient,
             ),
             child: NavigationToolbar(
-              middle: _title,
+              middle: title,
               centerMiddle: centerTitle,
               middleSpacing: 8,
             ),

--- a/lib/src/layout/title_bar.dart
+++ b/lib/src/layout/title_bar.dart
@@ -19,7 +19,7 @@ class TitleBar extends StatelessWidget {
   ///
   /// The height of the TitleBar can be changed with [height].
   const TitleBar({
-    Key? key,
+    super.key,
     this.height = kTitleBarHeight,
     this.alignment = Alignment.center,
     this.title,
@@ -27,7 +27,7 @@ class TitleBar extends StatelessWidget {
     this.decoration,
     this.centerTitle = true,
     this.dividerColor,
-  }) : super(key: key);
+  });
 
   /// Specifies the height of this [TitleBar].
   ///

--- a/lib/src/layout/toolbar/custom_toolbar_item.dart
+++ b/lib/src/layout/toolbar/custom_toolbar_item.dart
@@ -27,11 +27,11 @@ class CustomToolbarItem extends ToolbarItem {
   /// If [inOverflowedBuilder] is not provided, the custom toolbar item will not
   /// have an entry in the toolbar's overflowed menu (>>).
   const CustomToolbarItem({
-    Key? key,
+    super.key,
     required this.inToolbarBuilder,
     this.inOverflowedBuilder,
     this.tooltipMessage,
-  }) : super(key: key);
+  });
 
   /// Builds a custom widget to include in the [Toolbar].
   ///

--- a/lib/src/layout/toolbar/custom_toolbar_item.dart
+++ b/lib/src/layout/toolbar/custom_toolbar_item.dart
@@ -53,14 +53,14 @@ class CustomToolbarItem extends ToolbarItem {
   @override
   Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
-      Widget _widget = inToolbarBuilder(context);
+      Widget widget = inToolbarBuilder(context);
       if (tooltipMessage != null) {
-        _widget = MacosTooltip(
+        widget = MacosTooltip(
           message: tooltipMessage!,
-          child: _widget,
+          child: widget,
         );
       }
-      return _widget;
+      return widget;
     } else {
       return (inOverflowedBuilder != null)
           ? inOverflowedBuilder!(context)

--- a/lib/src/layout/toolbar/overflow_handler.dart
+++ b/lib/src/layout/toolbar/overflow_handler.dart
@@ -20,7 +20,7 @@ typedef OverflowHandlerChangedCallback = void Function(
 /// Adapted from [Wrap].
 class OverflowHandler extends MultiChildRenderObjectWidget {
   OverflowHandler({
-    Key? key,
+    super.key,
     this.alignment = MainAxisAlignment.start,
     this.crossAxisAlignment = CrossAxisAlignment.center,
     this.textDirection,
@@ -31,7 +31,7 @@ class OverflowHandler extends MultiChildRenderObjectWidget {
     this.overflowChangedCallback,
     required List<Widget> children,
     required Widget overflowWidget,
-  }) : super(key: key, children: [...children, overflowWidget]);
+  }) : super(children: [...children, overflowWidget]);
 
   /// {@macro flutter.widgets.wrap.alignment}
   final MainAxisAlignment alignment;

--- a/lib/src/layout/toolbar/overflow_handler.dart
+++ b/lib/src/layout/toolbar/overflow_handler.dart
@@ -490,7 +490,7 @@ class RenderOverflowHandler extends RenderBox
       if (overflowChangedCallback != null) {
         // This will likely trigger setState in a parent widget,
         // so schedule to happen at the end of the frame...
-        SchedulerBinding.instance?.addPostFrameCallback((_) {
+        SchedulerBinding.instance.addPostFrameCallback((_) {
           overflowChangedCallback!(hiddenChildren);
         });
       }

--- a/lib/src/layout/toolbar/toolbar.dart
+++ b/lib/src/layout/toolbar/toolbar.dart
@@ -31,7 +31,7 @@ class ToolBar extends StatefulWidget {
   ///
   /// The height of the ToolBar can be changed with [height].
   const ToolBar({
-    Key? key,
+    super.key,
     this.height = _kToolbarHeight,
     this.alignment = Alignment.center,
     this.title,
@@ -43,7 +43,7 @@ class ToolBar extends StatefulWidget {
     this.actions,
     this.centerTitle = false,
     this.dividerColor,
-  }) : super(key: key);
+  });
 
   /// Specifies the height of this [ToolBar].
   ///

--- a/lib/src/layout/toolbar/toolbar.dart
+++ b/lib/src/layout/toolbar/toolbar.dart
@@ -140,12 +140,12 @@ class _ToolBarState extends State<ToolBar> {
     final MacosThemeData theme = MacosTheme.of(context);
     Color dividerColor = widget.dividerColor ?? theme.dividerColor;
     final route = ModalRoute.of(context);
-    double _overflowBreakpoint = 0.0;
+    double overflowBreakpoint = 0.0;
 
-    Widget? _leading = widget.leading;
-    if (_leading == null && widget.automaticallyImplyLeading) {
+    Widget? leading = widget.leading;
+    if (leading == null && widget.automaticallyImplyLeading) {
       if (route?.canPop ?? false) {
-        _leading = Container(
+        leading = Container(
           width: _kLeadingWidth,
           alignment: Alignment.centerLeft,
           child: MacosBackButton(
@@ -156,15 +156,14 @@ class _ToolBarState extends State<ToolBar> {
       }
     }
     if (widget.leading != null) {
-      _overflowBreakpoint += _kLeadingWidth;
+      overflowBreakpoint += _kLeadingWidth;
     }
 
-    Widget? _title = widget.title;
-    if (_title != null) {
-      _title = SizedBox(
+    Widget? title = widget.title;
+    if (title != null) {
+      title = SizedBox(
         width: widget.titleWidth,
         child: DefaultTextStyle(
-          child: _title,
           style: MacosTheme.of(context).typography.headline.copyWith(
                 fontSize: 15,
                 fontWeight: FontWeight.w600,
@@ -172,20 +171,21 @@ class _ToolBarState extends State<ToolBar> {
                     ? const Color(0xFFEAEAEA)
                     : const Color(0xFF4D4D4D),
               ),
+          child: title,
         ),
       );
-      _overflowBreakpoint += widget.titleWidth;
+      overflowBreakpoint += widget.titleWidth;
     }
 
     // Collect the toolbar action widgets that can be shown inside the ToolBar
     // and the ones that have overflowed.
-    List<ToolbarItem>? _inToolbarActions = [];
-    List<ToolbarItem> _overflowedActions = [];
+    List<ToolbarItem>? inToolbarActions = [];
+    List<ToolbarItem> overflowedActions = [];
     bool doAllItemsShowLabel = true;
     if (widget.actions != null && widget.actions!.isNotEmpty) {
-      _inToolbarActions = widget.actions ?? [];
-      _overflowedActions = _inToolbarActions
-          .sublist(_inToolbarActions.length - overflowedActionsCount)
+      inToolbarActions = widget.actions ?? [];
+      overflowedActions = inToolbarActions
+          .sublist(inToolbarActions.length - overflowedActionsCount)
           .toList();
       // If all toolbar actions have labels shown below their icons,
       // reduce the overflow button's size as well.
@@ -226,14 +226,14 @@ class _ToolBarState extends State<ToolBar> {
               gradient: widget.decoration?.gradient,
             ),
             child: NavigationToolbar(
-              middle: _title,
+              middle: title,
               centerMiddle: widget.centerTitle,
               trailing: OverflowHandler(
-                overflowBreakpoint: _overflowBreakpoint,
+                overflowBreakpoint: overflowBreakpoint,
                 overflowWidget: ToolbarOverflowButton(
                   isDense: doAllItemsShowLabel,
                   overflowContentBuilder: (context) => ToolbarOverflowMenu(
-                    children: _overflowedActions
+                    children: overflowedActions
                         .map((action) => action.build(
                               context,
                               ToolbarItemDisplayMode.overflowed,
@@ -241,7 +241,7 @@ class _ToolBarState extends State<ToolBar> {
                         .toList(),
                   ),
                 ),
-                children: _inToolbarActions
+                children: inToolbarActions
                     .map((e) =>
                         e.build(context, ToolbarItemDisplayMode.inToolbar))
                     .toList(),
@@ -255,7 +255,7 @@ class _ToolBarState extends State<ToolBar> {
                 right: false,
                 bottom: false,
                 left: !(scope?.isSidebarShown ?? false),
-                child: _leading ?? const SizedBox.shrink(),
+                child: leading ?? const SizedBox.shrink(),
               ),
             ),
           ),

--- a/lib/src/layout/toolbar/toolbar_divider.dart
+++ b/lib/src/layout/toolbar/toolbar_divider.dart
@@ -18,19 +18,19 @@ class ToolBarDivider extends ToolbarItem {
 
   @override
   Widget build(BuildContext context, ToolbarItemDisplayMode displayMode) {
-    Color _color = MacosTheme.brightnessOf(context).resolve(
+    Color color = MacosTheme.brightnessOf(context).resolve(
       const Color.fromRGBO(0, 0, 0, 0.25),
       const Color.fromRGBO(255, 255, 255, 0.25),
     );
     if (displayMode == ToolbarItemDisplayMode.inToolbar) {
       return Padding(
         padding: padding!,
-        child: Container(color: _color, width: 1, height: 28),
+        child: Container(color: color, width: 1, height: 28),
       );
     } else {
       return Padding(
         padding: padding!,
-        child: Container(color: _color, height: 1),
+        child: Container(color: color, height: 1),
       );
     }
   }

--- a/lib/src/layout/toolbar/toolbar_divider.dart
+++ b/lib/src/layout/toolbar/toolbar_divider.dart
@@ -7,9 +7,9 @@ class ToolBarDivider extends ToolbarItem {
   /// line (or a horizontal line, if it appears in the overflowed menu) between
   /// the toolbar actions.
   const ToolBarDivider({
-    Key? key,
+    super.key,
     this.padding = const EdgeInsets.all(6.0),
-  }) : super(key: key);
+  });
 
   /// Optional padding to use for the divider.
   ///

--- a/lib/src/layout/toolbar/toolbar_overflow_menu.dart
+++ b/lib/src/layout/toolbar/toolbar_overflow_menu.dart
@@ -10,9 +10,9 @@ class ToolbarOverflowMenu extends StatelessWidget {
   ///
   /// Has a similar styling to a pulldown menu.
   const ToolbarOverflowMenu({
-    Key? key,
+    super.key,
     required this.children,
-  }) : super(key: key);
+  });
 
   /// The list of children widgets to lay out vertically inside the menu.
   final List<Widget> children;

--- a/lib/src/layout/toolbar/toolbar_overflow_menu_item.dart
+++ b/lib/src/layout/toolbar/toolbar_overflow_menu_item.dart
@@ -6,12 +6,12 @@ import 'package:macos_ui/src/library.dart';
 class ToolbarOverflowMenuItem extends StatefulWidget {
   /// Builds a menu-item that belongs in the toolbar overflowed actions menu.
   const ToolbarOverflowMenuItem({
-    Key? key,
+    super.key,
     this.onPressed,
     required this.label,
     this.subMenuItems,
     this.isSelected,
-  }) : super(key: key);
+  });
 
   /// The callback that is called when the menu item is tapped or otherwise
   /// activated.

--- a/lib/src/layout/toolbar/toolbar_popup.dart
+++ b/lib/src/layout/toolbar/toolbar_popup.dart
@@ -31,14 +31,14 @@ class ToolbarPopup<T> extends StatefulWidget {
   /// Creates a popup for the toolbar. Used for the menu that encapsulates
   /// the overflowed toolbar actions and its possible submenus.
   const ToolbarPopup({
-    Key? key,
+    super.key,
     required this.child,
     required this.content,
     this.verticalOffset = 0,
     this.horizontalOffset = 0,
     this.placement = ToolbarPopupPlacement.center,
     this.position = ToolbarPopupPosition.above,
-  }) : super(key: key);
+  });
 
   final Widget child;
   final WidgetBuilder content;
@@ -159,12 +159,12 @@ class ToolbarPopupState<T> extends State<ToolbarPopup<T>> {
 
 class _ToolbarPopupMenu<T> extends StatefulWidget {
   const _ToolbarPopupMenu({
-    Key? key,
+    super.key,
     required this.route,
     required this.buttonRect,
     required this.constraints,
     this.dropdownColor,
-  }) : super(key: key);
+  });
 
   final _ToolbarPopupRoute<T> route;
   final Rect buttonRect;
@@ -342,7 +342,7 @@ class _ToolbarPopupRoute<T> extends PopupRoute<T> {
 
 class _ToolbarPopupRoutePage<T> extends StatelessWidget {
   const _ToolbarPopupRoutePage({
-    Key? key,
+    super.key,
     required this.route,
     required this.constraints,
     required this.content,
@@ -356,7 +356,7 @@ class _ToolbarPopupRoutePage<T> extends StatelessWidget {
     required this.placement,
     required this.placementOffset,
     required this.position,
-  }) : super(key: key);
+  });
 
   final _ToolbarPopupRoute<T> route;
   final BoxConstraints constraints;
@@ -412,6 +412,7 @@ class _ToolbarPopupRoutePage<T> extends StatelessWidget {
 }
 
 class _ToolbarPopupContentManager extends StatefulWidget {
+  // ignore: use_super_parameters
   const _ToolbarPopupContentManager({
     Key? key,
     required this.content,
@@ -454,11 +455,12 @@ class _ToolbarPopupContentManagerState
 }
 
 class _ToolbarPopupContentSizeInfo extends InheritedWidget {
+  // ignore: use_super_parameters
   const _ToolbarPopupContentSizeInfo({
     Key? key,
-    required Widget child,
+    required super.child,
     required this.size,
-  }) : super(key: key, child: child);
+  }) : super(key: key);
 
   final Size size;
 

--- a/lib/src/layout/toolbar/toolbar_popup.dart
+++ b/lib/src/layout/toolbar/toolbar_popup.dart
@@ -432,7 +432,7 @@ class _ToolbarPopupContentManagerState
 
   @override
   void initState() {
-    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       final context = key.currentContext;
       if (context == null) return;
       final RenderBox box = context.findRenderObject() as RenderBox;

--- a/lib/src/layout/toolbar/toolbar_spacer.dart
+++ b/lib/src/layout/toolbar/toolbar_spacer.dart
@@ -8,9 +8,9 @@ class ToolBarSpacer extends ToolbarItem {
   /// Builds a spacer utility widget for the toolbar. It generates blank space
   /// between the toolbar actions.
   const ToolBarSpacer({
-    Key? key,
+    super.key,
     this.spacerUnits = 1.0,
-  }) : super(key: key);
+  });
 
   /// How much space to generate, expressed in multiples of [_kToolbarItemWidth]
   ///

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -22,12 +22,12 @@ class MacosWindow extends StatefulWidget {
   /// The [child] widget is typically a [MacosScaffold] which fills the
   /// rest of the screen.
   const MacosWindow({
-    Key? key,
+    super.key,
     this.child,
     this.titleBar,
     this.sidebar,
     this.backgroundColor,
-  }) : super(key: key);
+  });
 
   /// Specifies the background color for the Window.
   ///
@@ -322,13 +322,12 @@ class MacosWindowScope extends InheritedWidget {
   /// The [constraints], [contentAreaWidth], [child], [valueNotifier]
   /// and [_scaffoldState] arguments are required and must not be null.
   const MacosWindowScope({
-    Key? key,
+    super.key,
     required this.constraints,
-    required Widget child,
+    required super.child,
     required this.isSidebarShown,
     required VoidCallback sidebarToggler,
-  })  : _sidebarToggler = sidebarToggler,
-        super(key: key, child: child);
+  })  : _sidebarToggler = sidebarToggler;
 
   /// Provides the constraints from the [MacosWindow] to its descendants.
   final BoxConstraints constraints;

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -327,7 +327,7 @@ class MacosWindowScope extends InheritedWidget {
     required super.child,
     required this.isSidebarShown,
     required VoidCallback sidebarToggler,
-  })  : _sidebarToggler = sidebarToggler;
+  }) : _sidebarToggler = sidebarToggler;
 
   /// Provides the constraints from the [MacosWindow] to its descendants.
   final BoxConstraints constraints;

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -44,7 +44,7 @@ class MacosWindow extends StatefulWidget {
   final Sidebar? sidebar;
 
   @override
-  _MacosWindowState createState() => _MacosWindowState();
+  State<MacosWindow> createState() => _MacosWindowState();
 }
 
 class _MacosWindowState extends State<MacosWindow> {
@@ -289,7 +289,6 @@ class _MacosWindowState extends State<MacosWindow> {
         );
 
         return MacosWindowScope(
-          child: layout,
           constraints: constraints,
           isSidebarShown: canShowSidebar,
           sidebarToggler: () async {
@@ -298,6 +297,7 @@ class _MacosWindowState extends State<MacosWindow> {
             await Future.delayed(Duration(milliseconds: _sidebarSlideDuration));
             setState(() => _sidebarSlideDuration = 0);
           },
+          child: layout,
         );
       },
     );

--- a/lib/src/macos_app.dart
+++ b/lib/src/macos_app.dart
@@ -298,7 +298,7 @@ class MacosApp extends StatefulWidget {
   final MacosThemeData? theme;
 
   @override
-  _MacosAppState createState() => _MacosAppState();
+  State<MacosApp> createState() => _MacosAppState();
 }
 
 class _MacosAppState extends State<MacosApp> {
@@ -443,8 +443,8 @@ class MacosScrollBehavior extends ScrollBehavior {
           case TargetPlatform.macOS:
           case TargetPlatform.windows:
             return MacosScrollbar(
-              child: child,
               controller: details.controller,
+              child: child,
             );
           case TargetPlatform.android:
           case TargetPlatform.fuchsia:

--- a/lib/src/macos_app.dart
+++ b/lib/src/macos_app.dart
@@ -39,7 +39,7 @@ class MacosApp extends StatefulWidget {
   ///
   /// The boolean arguments, [routes], and [navigatorObservers], must not be null.
   const MacosApp({
-    Key? key,
+    super.key,
     this.navigatorKey,
     this.home,
     Map<String, Widget Function(BuildContext)> this.routes =
@@ -74,12 +74,11 @@ class MacosApp extends StatefulWidget {
   })  : routeInformationProvider = null,
         routeInformationParser = null,
         routerDelegate = null,
-        backButtonDispatcher = null,
-        super(key: key);
+        backButtonDispatcher = null;
 
   /// Creates a [MacosApp] that uses the [Router] instead of a [Navigator].
   MacosApp.router({
-    Key? key,
+    super.key,
     this.routeInformationProvider,
     required RouteInformationParser<Object> this.routeInformationParser,
     required RouterDelegate<Object> this.routerDelegate,
@@ -113,8 +112,7 @@ class MacosApp extends StatefulWidget {
         onGenerateInitialRoutes = null,
         onUnknownRoute = null,
         routes = null,
-        initialRoute = null,
-        super(key: key);
+        initialRoute = null;
 
   /// {@macro flutter.widgets.widgetsApp.navigatorKey}
   final GlobalKey<NavigatorState>? navigatorKey;

--- a/lib/src/selectors/color_well.dart
+++ b/lib/src/selectors/color_well.dart
@@ -58,10 +58,10 @@ typedef OnColorSelected = void Function(Color color);
 class MacosColorWell extends StatefulWidget {
   /// {@macro macosColorWell}
   const MacosColorWell({
-    Key? key,
+    super.key,
     required this.onColorSelected,
     this.defaultMode = ColorPickerMode.wheel,
-  }) : super(key: key);
+  });
 
   /// {@macro onColorSelected}
   final OnColorSelected onColorSelected;

--- a/lib/src/selectors/color_well.dart
+++ b/lib/src/selectors/color_well.dart
@@ -104,8 +104,8 @@ class _MacosColorWellState extends State<MacosColorWell> {
 
   @override
   Widget build(BuildContext context) {
-    final _theme = MacosTheme.of(context);
-    final _outerColor = _theme.brightness.isDark
+    final theme = MacosTheme.of(context);
+    final outerColor = theme.brightness.isDark
         ? MacosColors.systemGrayColor.withOpacity(0.50)
         : MacosColors.white;
     return GestureDetector(
@@ -126,7 +126,7 @@ class _MacosColorWellState extends State<MacosColorWell> {
         height: 23.0,
         width: 44.0,
         child: Container(
-          decoration: !_theme.brightness.isDark
+          decoration: !theme.brightness.isDark
               ? BoxDecoration(
                   border: Border.all(
                     color: const MacosColor(0xFFAFAEAE),
@@ -135,7 +135,7 @@ class _MacosColorWellState extends State<MacosColorWell> {
                 )
               : null,
           child: ColoredBox(
-            color: _outerColor,
+            color: outerColor,
             child: Padding(
               padding: const EdgeInsets.all(6.0),
               child: SizedBox(

--- a/lib/src/selectors/date_picker.dart
+++ b/lib/src/selectors/date_picker.dart
@@ -35,10 +35,10 @@ typedef OnDateChanged = Function(DateTime date);
 class MacosDatePicker extends StatefulWidget {
   /// {macro macosDatePicker}
   const MacosDatePicker({
-    Key? key,
+    super.key,
     this.style = DatePickerStyle.combined,
     required this.onDateChanged,
-  }) : super(key: key);
+  });
 
   /// The [DatePickerStyle] to use.
   ///
@@ -586,11 +586,11 @@ const _DayPickerGridDelegate _dayPickerGridDelegate = _DayPickerGridDelegate();
 
 class DatePickerFieldElement extends StatelessWidget {
   const DatePickerFieldElement({
-    Key? key,
+    super.key,
     required this.element,
     required this.onSelected,
     required this.isSelected,
-  }) : super(key: key);
+  });
 
   final String element;
   final VoidCallback onSelected;

--- a/lib/src/selectors/keyboard_shortcut_runner.dart
+++ b/lib/src/selectors/keyboard_shortcut_runner.dart
@@ -22,12 +22,12 @@ final decrementKeyset = LogicalKeySet(LogicalKeyboardKey.arrowDown);
 class KeyboardShortcutRunner extends StatelessWidget {
   /// {@macro keyboardShortcutRunner}.
   const KeyboardShortcutRunner({
-    Key? key,
+    super.key,
     required this.child,
     required this.onUpArrowKeypress,
     required this.onDownArrowKeypress,
     this.focusNode,
-  }) : super(key: key);
+  });
 
   /// This child of this widget.
   final Widget child;

--- a/lib/src/selectors/time_picker.dart
+++ b/lib/src/selectors/time_picker.dart
@@ -40,10 +40,10 @@ typedef OnTimeChanged = Function(TimeOfDay time);
 class MacosTimePicker extends StatefulWidget {
   /// {@macro macosTimePicker}
   const MacosTimePicker({
-    Key? key,
+    super.key,
     required this.onTimeChanged,
     this.style = TimePickerStyle.combined,
-  }) : super(key: key);
+  });
 
   /// The [TimePickerStyle] to use.
   ///
@@ -374,11 +374,11 @@ class _MacosTimePickerState extends State<MacosTimePicker> {
 
 class TimePickerFieldElement extends StatelessWidget {
   const TimePickerFieldElement({
-    Key? key,
+    super.key,
     required this.element,
     required this.onSelected,
     required this.isSelected,
-  }) : super(key: key);
+  });
 
   final String element;
   final VoidCallback onSelected;

--- a/lib/src/selectors/time_picker.dart
+++ b/lib/src/selectors/time_picker.dart
@@ -327,14 +327,14 @@ class _MacosTimePickerState extends State<MacosTimePicker> {
   }
 
   Widget _buildGraphicalTimePicker(MacosTimePickerThemeData timePickerTheme) {
-    const _clockHeight = 116.0;
-    const _clockWidth = 115.0;
+    const clockHeight = 116.0;
+    const clockWidth = 115.0;
     return SizedBox(
-      height: _clockHeight,
-      width: _clockWidth,
+      height: clockHeight,
+      width: clockWidth,
       child: CustomPaint(
         painter: GraphicalTimePickerPainter(
-          clockHeight: _clockHeight,
+          clockHeight: clockHeight,
           time: DateTime(
             DateTime.now().year,
             DateTime.now().month,

--- a/lib/src/sheets/macos_sheet.dart
+++ b/lib/src/sheets/macos_sheet.dart
@@ -10,12 +10,12 @@ const EdgeInsets _defaultInsetPadding =
 /// interaction with the window until the sheet is dismissed.
 class MacosSheet extends StatelessWidget {
   const MacosSheet({
-    Key? key,
+    super.key,
     required this.child,
     this.insetPadding = _defaultInsetPadding,
     this.insetAnimationDuration = const Duration(milliseconds: 100),
     this.insetAnimationCurve = Curves.decelerate,
-  }) : super(key: key);
+  });
 
   /// The widget below this widget in the tree.
   final Widget child;
@@ -120,12 +120,11 @@ class _MacosSheetRoute<T> extends PopupRoute<T> {
     bool barrierDismissible = false,
     Color? barrierColor = const Color(0x80000000),
     String? barrierLabel,
-    RouteSettings? settings,
+    super.settings,
   })  : _pageBuilder = pageBuilder,
         _barrierDismissible = barrierDismissible,
         _barrierLabel = barrierLabel,
-        _barrierColor = barrierColor,
-        super(settings: settings);
+        _barrierColor = barrierColor;
 
   final RoutePageBuilder _pageBuilder;
 

--- a/lib/src/theme/date_picker_theme.dart
+++ b/lib/src/theme/date_picker_theme.dart
@@ -12,10 +12,10 @@ class MacosDatePickerTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const MacosDatePickerTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final MacosDatePickerThemeData data;

--- a/lib/src/theme/help_button_theme.dart
+++ b/lib/src/theme/help_button_theme.dart
@@ -12,10 +12,10 @@ class HelpButtonTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const HelpButtonTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final HelpButtonThemeData data;

--- a/lib/src/theme/icon_button_theme.dart
+++ b/lib/src/theme/icon_button_theme.dart
@@ -12,10 +12,10 @@ class MacosIconButtonTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const MacosIconButtonTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final MacosIconButtonThemeData data;

--- a/lib/src/theme/icon_theme.dart
+++ b/lib/src/theme/icon_theme.dart
@@ -13,10 +13,10 @@ class MacosIconTheme extends InheritedTheme {
   ///
   /// Both [data] and [child] arguments must not be null.
   const MacosIconTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// Creates an icon theme that controls the color, opacity, and size of
   /// descendant widgets, and merges in the current icon theme, if any.

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -3,7 +3,7 @@ import 'package:macos_ui/src/library.dart';
 /// An immutable 32 bit color value in ARGB format.
 class MacosColor extends Color {
   /// Construct a color from the lower 32 bits of an [int].
-  const MacosColor(int value) : super(value);
+  const MacosColor(super.value);
 
   /// Construct a color from the lower 8 bits of four integers.
   ///
@@ -17,8 +17,8 @@ class MacosColor extends Color {
   ///
   /// See also [fromRGBO], which takes the alpha value as a floating point
   /// value.
-  const MacosColor.fromARGB(int a, int r, int g, int b)
-      : super.fromARGB(a, r, g, b);
+  const MacosColor.fromARGB(super.a, super.r, super.g, super.b)
+      : super.fromARGB();
 
   /// Create a color from red, green, blue, and opacity, similar to `rgba()`
   /// in CSS.
@@ -32,8 +32,8 @@ class MacosColor extends Color {
   /// Out of range values are brought into range using modulo 255.
   ///
   /// See also [fromARGB], which takes the opacity as an integer value.
-  const MacosColor.fromRGBO(int r, int g, int b, double opcacity)
-      : super.fromRGBO(r, g, b, opcacity);
+  const MacosColor.fromRGBO(super.r, super.g, super.b, super.opcacity)
+      : super.fromRGBO();
 
   /// Linearly interpolate between two [MacosColor]s.
   static MacosColor lerp(MacosColor a, MacosColor b, double t) {

--- a/lib/src/theme/macos_dynamic_color.dart
+++ b/lib/src/theme/macos_dynamic_color.dart
@@ -104,9 +104,9 @@ extension MacosDynamicColor on CupertinoDynamicColor {
         }
     }
 
-    Element? _debugContext;
+    Element? debugContext;
     assert(() {
-      _debugContext = context as Element;
+      debugContext = context as Element;
       return true;
     }());
 
@@ -120,7 +120,7 @@ extension MacosDynamicColor on CupertinoDynamicColor {
       darkElevatedColor,
       highContrastElevatedColor,
       darkHighContrastElevatedColor,
-      _debugContext,
+      debugContext,
     );
   }
 }

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -21,10 +21,10 @@ class MacosTheme extends StatelessWidget {
   ///
   /// The [data] and [child] parameters must not be null.
   const MacosTheme({
-    Key? key,
+    super.key,
     required this.data,
     required this.child,
-  }) : super(key: key);
+  });
 
   /// The [MacosThemeData] styling for this theme.
   final MacosThemeData data;
@@ -120,11 +120,12 @@ class MacosTheme extends StatelessWidget {
 }
 
 class _InheritedMacosTheme extends InheritedWidget {
+  // ignore: use_super_parameters
   const _InheritedMacosTheme({
     Key? key,
     required this.theme,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  }) : super(key: key);
 
   final MacosTheme theme;
 

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -203,6 +203,7 @@ class MacosThemeData with Diagnosticable {
     MacosTimePickerThemeData? timePickerTheme,
     MacosSearchFieldThemeData? searchFieldTheme,
   }) {
+    // ignore: no_leading_underscores_for_local_identifiers
     final Brightness _brightness = brightness ?? Brightness.light;
     final bool isDark = _brightness == Brightness.dark;
     primaryColor ??= MacosColors.controlAccentColor;
@@ -210,7 +211,7 @@ class MacosThemeData with Diagnosticable {
         ? CupertinoColors.systemBackground.darkElevatedColor
         : CupertinoColors.systemBackground;
     typography ??= MacosTypography(
-      color: brightness == Brightness.light
+      color: _brightness == Brightness.light
           ? CupertinoColors.black
           : CupertinoColors.white,
     );
@@ -625,7 +626,8 @@ class MacosThemeData with Diagnosticable {
       DiagnosticsProperty<TooltipThemeData>('tooltipTheme', tooltipTheme),
     );
     properties.add(
-      DiagnosticsProperty<MacosScrollbarThemeData>('scrollbarTheme', scrollbarTheme),
+      DiagnosticsProperty<MacosScrollbarThemeData>(
+          'scrollbarTheme', scrollbarTheme),
     );
     properties.add(
       DiagnosticsProperty<MacosIconButtonThemeData>(

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -194,7 +194,7 @@ class MacosThemeData with Diagnosticable {
     HelpButtonThemeData? helpButtonTheme,
     TooltipThemeData? tooltipTheme,
     VisualDensity? visualDensity,
-    ScrollbarThemeData? scrollbarTheme,
+    MacosScrollbarThemeData? scrollbarTheme,
     MacosIconButtonThemeData? macosIconButtonTheme,
     MacosIconThemeData? iconTheme,
     MacosPopupButtonThemeData? popupButtonTheme,
@@ -236,7 +236,7 @@ class MacosThemeData with Diagnosticable {
       brightness: _brightness,
       textStyle: typography.callout,
     );
-    scrollbarTheme ??= const ScrollbarThemeData();
+    scrollbarTheme ??= const MacosScrollbarThemeData();
     macosIconButtonTheme ??= MacosIconButtonThemeData(
       backgroundColor: MacosColors.transparent,
       disabledColor: isDark
@@ -471,7 +471,7 @@ class MacosThemeData with Diagnosticable {
   final VisualDensity visualDensity;
 
   /// The default style for [MacosScrollbar]s below the overall [MacosTheme]
-  final ScrollbarThemeData scrollbarTheme;
+  final MacosScrollbarThemeData scrollbarTheme;
 
   /// The default style for [MacosIconButton]s below the overall [MacosTheme]
   final MacosIconButtonThemeData iconButtonTheme;
@@ -505,7 +505,7 @@ class MacosThemeData with Diagnosticable {
       tooltipTheme: TooltipThemeData.lerp(a.tooltipTheme, b.tooltipTheme, t),
       visualDensity: VisualDensity.lerp(a.visualDensity, b.visualDensity, t),
       scrollbarTheme:
-          ScrollbarThemeData.lerp(a.scrollbarTheme, b.scrollbarTheme, t),
+          MacosScrollbarThemeData.lerp(a.scrollbarTheme, b.scrollbarTheme, t),
       iconButtonTheme: MacosIconButtonThemeData.lerp(
         a.iconButtonTheme,
         b.iconButtonTheme,
@@ -551,7 +551,7 @@ class MacosThemeData with Diagnosticable {
     HelpButtonThemeData? helpButtonTheme,
     TooltipThemeData? tooltipTheme,
     VisualDensity? visualDensity,
-    ScrollbarThemeData? scrollbarTheme,
+    MacosScrollbarThemeData? scrollbarTheme,
     MacosIconButtonThemeData? iconButtonTheme,
     MacosIconThemeData? iconTheme,
     MacosPopupButtonThemeData? popupButtonTheme,
@@ -625,7 +625,7 @@ class MacosThemeData with Diagnosticable {
       DiagnosticsProperty<TooltipThemeData>('tooltipTheme', tooltipTheme),
     );
     properties.add(
-      DiagnosticsProperty<ScrollbarThemeData>('scrollbarTheme', scrollbarTheme),
+      DiagnosticsProperty<MacosScrollbarThemeData>('scrollbarTheme', scrollbarTheme),
     );
     properties.add(
       DiagnosticsProperty<MacosIconButtonThemeData>(

--- a/lib/src/theme/overlay_filter.dart
+++ b/lib/src/theme/overlay_filter.dart
@@ -12,11 +12,11 @@ class MacosOverlayFilter extends StatelessWidget {
   /// Used mainly for the overlays that appear from various macOS-style widgets,
   /// like the pull-down and pop-up buttons, or the search field.
   const MacosOverlayFilter({
-    Key? key,
+    super.key,
     required this.child,
     required this.borderRadius,
     this.color,
-  }) : super(key: key);
+  });
 
   /// The widget to apply the blur filter to.
   final Widget child;

--- a/lib/src/theme/popup_button_theme.dart
+++ b/lib/src/theme/popup_button_theme.dart
@@ -12,10 +12,10 @@ class MacosPopupButtonTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const MacosPopupButtonTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final MacosPopupButtonThemeData data;

--- a/lib/src/theme/pulldown_button_theme.dart
+++ b/lib/src/theme/pulldown_button_theme.dart
@@ -12,10 +12,10 @@ class MacosPulldownButtonTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const MacosPulldownButtonTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final MacosPulldownButtonThemeData data;

--- a/lib/src/theme/push_button_theme.dart
+++ b/lib/src/theme/push_button_theme.dart
@@ -12,10 +12,10 @@ class PushButtonTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const PushButtonTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final PushButtonThemeData data;

--- a/lib/src/theme/scrollbar_theme.dart
+++ b/lib/src/theme/scrollbar_theme.dart
@@ -6,30 +6,31 @@ import 'package:macos_ui/src/library.dart';
 
 /// Applies a scrollbar theme to descendant [MacosScrollbar] widgets.
 ///
-/// Descendant widgets obtain the current theme's [ScrollbarThemeData] using
-/// [ScrollbarTheme.of]. When a widget uses [ScrollbarTheme.of], it is
-/// automatically rebuilt if the theme later changes.
+/// Descendant widgets obtain the current theme's [MacosScrollbarThemeData]
+/// using [MacosScrollbarTheme.of]. When a widget uses
+/// [MacosScrollbarTheme.of], it is automatically rebuilt if the theme later
+/// changes.
 ///
 /// A scrollbar theme can be specified as part of the overall Material theme
 /// using [ThemeData.scrollbarTheme].
 ///
 /// See also:
 ///
-///  * [ScrollbarThemeData], which describes the configuration of a
+///  * [MacosScrollbarThemeData], which describes the configuration of a
 ///    scrollbar theme.
-class ScrollbarTheme extends InheritedWidget {
-  /// Constructs a scrollbar theme that configures all descendant [MacosScrollbar]
-  /// widgets.
-  const ScrollbarTheme({
+class MacosScrollbarTheme extends InheritedWidget {
+  /// Constructs a scrollbar theme that configures all descendant
+  /// [MacosScrollbar] widgets.
+  const MacosScrollbarTheme({
     Key? key,
     required this.data,
     required Widget child,
   }) : super(key: key, child: child);
 
   /// The properties used for all descendant [MacosScrollbar] widgets.
-  final ScrollbarThemeData data;
+  final MacosScrollbarThemeData data;
 
-  /// Returns the configuration [data] from the closest [ScrollbarTheme]
+  /// Returns the configuration [data] from the closest [MacosScrollbarTheme]
   /// ancestor. If there is no ancestor, it returns [ThemeData.scrollbarTheme].
   ///
   /// Typical usage is as follows:
@@ -37,35 +38,36 @@ class ScrollbarTheme extends InheritedWidget {
   /// ```dart
   /// ScrollbarThemeData theme = ScrollbarTheme.of(context);
   /// ```
-  static ScrollbarThemeData of(BuildContext context) {
-    final ScrollbarTheme? scrollbarTheme =
-        context.dependOnInheritedWidgetOfExactType<ScrollbarTheme>();
+  static MacosScrollbarThemeData of(BuildContext context) {
+    final MacosScrollbarTheme? scrollbarTheme =
+        context.dependOnInheritedWidgetOfExactType<MacosScrollbarTheme>();
     return scrollbarTheme?.data ?? MacosTheme.of(context).scrollbarTheme;
   }
 
   @override
-  bool updateShouldNotify(ScrollbarTheme oldWidget) => data != oldWidget.data;
+  bool updateShouldNotify(MacosScrollbarTheme oldWidget) => data != oldWidget.data;
 }
 
 /// Defines default property values for descendant [MacosScrollbar] widgets.
 ///
-/// Descendant widgets obtain the current [ScrollbarThemeData] object with
-/// `ScrollbarTheme.of(context)`. Instances of [ScrollbarThemeData] can be customized
-/// with [ScrollbarThemeData.copyWith].
+/// Descendant widgets obtain the current [MacosScrollbarThemeData] object with
+/// `ScrollbarTheme.of(context)`. Instances of [MacosScrollbarThemeData] can
+/// be customized with [MacosScrollbarThemeData.copyWith].
 ///
-/// Typically the [ScrollbarThemeData] of a [ScrollbarTheme] is specified as part of the overall
-/// [MacosTheme] with [MacosThemeData.scrollbarTheme].
+/// Typically the [MacosScrollbarThemeData] of a [MacosScrollbarTheme] is
+/// specified as part of the overall [MacosTheme] with
+/// [MacosThemeData.scrollbarTheme].
 ///
-/// All [ScrollbarThemeData] properties are `null` by default. When null, the [MacosScrollbar]
-/// computes its own default values.
+/// All [MacosScrollbarThemeData] properties are `null` by default. When null,
+/// the [MacosScrollbar] computes its own default values.
 ///
 /// See also:
 ///
 ///  * [MacosThemeData], which describes the overall theme information for the
 ///    application.
-class ScrollbarThemeData with Diagnosticable {
+class MacosScrollbarThemeData with Diagnosticable {
   /// Creates a theme that can be used for [MacosThemeData.scrollbarTheme].
-  const ScrollbarThemeData({
+  const MacosScrollbarThemeData({
     this.thickness,
     this.hoveringThickness,
     this.showTrackOnHover,
@@ -92,7 +94,7 @@ class ScrollbarThemeData with Diagnosticable {
   /// descendant [MacosScrollbar] widgets when hovering is active.
   final double? hoveringThickness;
 
-  /// Overrides the default value of [MacosScrollbar.showTrackOnHover] in all
+  /// Overrides the default value of [MacosScrollbar.trackVisibility] in all
   /// descendant [MacosScrollbar] widgets.
   final bool? showTrackOnHover;
 
@@ -108,16 +110,16 @@ class ScrollbarThemeData with Diagnosticable {
   /// descendant widgets.
   final Radius? radius;
 
-  /// Overrides the default [Color] of the [MacosScrollbar] thumb in all descendant
-  /// [MacosScrollbar] widgets.
+  /// Overrides the default [Color] of the [MacosScrollbar] thumb in all
+  /// descendant [MacosScrollbar] widgets.
   final Color? thumbColor;
 
-  /// Overrides the default [Color] of the [MacosScrollbar] thumb in all descendant
-  /// [MacosScrollbar] widgets when hovering is active.
+  /// Overrides the default [Color] of the [MacosScrollbar] thumb in all
+  /// descendant [MacosScrollbar] widgets when hovering is active.
   final Color? hoveringThumbColor;
 
-  /// Overrides the default [Color] of the [MacosScrollbar] thumb in all descendant
-  /// [MacosScrollbar] widgets when dragging is active.
+  /// Overrides the default [Color] of the [MacosScrollbar] thumb in all
+  /// descendant [MacosScrollbar] widgets when dragging is active.
   final Color? draggingThumbColor;
 
   /// Overrides the default [Color] of the [MacosScrollbar] track when
@@ -169,7 +171,7 @@ class ScrollbarThemeData with Diagnosticable {
 
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
-  ScrollbarThemeData copyWith({
+  MacosScrollbarThemeData copyWith({
     double? thickness,
     double? hoveringThickness,
     bool? showTrackOnHover,
@@ -187,7 +189,7 @@ class ScrollbarThemeData with Diagnosticable {
     double? mainAxisMargin,
     double? minThumbLength,
   }) {
-    return ScrollbarThemeData(
+    return MacosScrollbarThemeData(
       thickness: thickness ?? this.thickness,
       hoveringThickness: hoveringThickness ?? this.hoveringThickness,
       showTrackOnHover: showTrackOnHover ?? this.showTrackOnHover,
@@ -214,12 +216,12 @@ class ScrollbarThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   // ignore: code-metrics
-  static ScrollbarThemeData lerp(
-    ScrollbarThemeData? a,
-    ScrollbarThemeData? b,
+  static MacosScrollbarThemeData lerp(
+    MacosScrollbarThemeData? a,
+    MacosScrollbarThemeData? b,
     double t,
   ) {
-    return ScrollbarThemeData(
+    return MacosScrollbarThemeData(
       thickness: lerpDouble(a?.thickness, b?.thickness, t),
       hoveringThickness:
           lerpDouble(a?.hoveringThickness, b?.hoveringThickness, t),
@@ -273,7 +275,7 @@ class ScrollbarThemeData with Diagnosticable {
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other.runtimeType != runtimeType) return false;
-    return other is ScrollbarThemeData &&
+    return other is MacosScrollbarThemeData &&
         other.thickness == thickness &&
         other.hoveringThickness == hoveringThickness &&
         other.showTrackOnHover == showTrackOnHover &&
@@ -363,7 +365,7 @@ class ScrollbarThemeData with Diagnosticable {
     ));
   }
 
-  ScrollbarThemeData merge(ScrollbarThemeData? other) {
+  MacosScrollbarThemeData merge(MacosScrollbarThemeData? other) {
     if (other == null) return this;
     return copyWith(
       thickness: other.thickness,

--- a/lib/src/theme/scrollbar_theme.dart
+++ b/lib/src/theme/scrollbar_theme.dart
@@ -45,7 +45,8 @@ class MacosScrollbarTheme extends InheritedWidget {
   }
 
   @override
-  bool updateShouldNotify(MacosScrollbarTheme oldWidget) => data != oldWidget.data;
+  bool updateShouldNotify(MacosScrollbarTheme oldWidget) =>
+      data != oldWidget.data;
 }
 
 /// Defines default property values for descendant [MacosScrollbar] widgets.

--- a/lib/src/theme/scrollbar_theme.dart
+++ b/lib/src/theme/scrollbar_theme.dart
@@ -22,10 +22,10 @@ class MacosScrollbarTheme extends InheritedWidget {
   /// Constructs a scrollbar theme that configures all descendant
   /// [MacosScrollbar] widgets.
   const MacosScrollbarTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The properties used for all descendant [MacosScrollbar] widgets.
   final MacosScrollbarThemeData data;

--- a/lib/src/theme/search_field_theme.dart
+++ b/lib/src/theme/search_field_theme.dart
@@ -12,10 +12,10 @@ class MacosSearchFieldTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const MacosSearchFieldTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final MacosSearchFieldThemeData data;

--- a/lib/src/theme/time_picker_theme.dart
+++ b/lib/src/theme/time_picker_theme.dart
@@ -12,10 +12,10 @@ class MacosTimePickerTheme extends InheritedTheme {
   ///
   /// The [data] parameter must not be null.
   const MacosTimePickerTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration of this theme.
   final MacosTimePickerThemeData data;

--- a/lib/src/theme/tooltip_theme.dart
+++ b/lib/src/theme/tooltip_theme.dart
@@ -12,10 +12,10 @@ class TooltipTheme extends InheritedTheme {
   ///
   /// The data argument must not be null.
   const TooltipTheme({
-    Key? key,
+    super.key,
     required this.data,
-    required Widget child,
-  }) : super(key: key, child: child);
+    required super.child,
+  });
 
   /// The configuration for this theme
   final TooltipThemeData data;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -84,7 +84,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   file:
     dependency: transitive
     description:
@@ -234,7 +234,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -276,7 +276,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   petitparser:
     dependency: transitive
     description:
@@ -351,7 +351,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -386,21 +386,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.19.5"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.11"
   typed_data:
     dependency: transitive
     description:
@@ -414,7 +414,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
@@ -458,5 +458,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -152,7 +152,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -213,7 +213,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.3.0
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.3.0
+version: 1.4.0
 homepage: "https://github.com/GroovinChip/macos_ui"
 
 environment:
@@ -15,7 +15,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   dart_code_metrics: ^4.14.0
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   mocktail: ^0.3.0
 
 flutter:

--- a/test/buttons/push_button_test.dart
+++ b/test/buttons/push_button_test.dart
@@ -28,8 +28,8 @@ void main() {
                   builder: (context, scrollController) {
                     return PushButton(
                       buttonSize: ButtonSize.small,
-                      child: const Text('Push me'),
                       onPressed: mockOnPressedFunction.handler,
+                      child: const Text('Push me'),
                     );
                   },
                 ),
@@ -61,9 +61,9 @@ void main() {
                   builder: (context, scrollController) {
                     return PushButton(
                       buttonSize: ButtonSize.small,
-                      child: const Text('Push me'),
                       key: pushButtonKey,
                       onPressed: mockOnTapCancelFunction.handler,
+                      child: const Text('Push me'),
                     );
                   },
                 ),

--- a/test/theme/scrollbar_theme_test.dart
+++ b/test/theme/scrollbar_theme_test.dart
@@ -6,17 +6,17 @@ import 'package:macos_ui/src/library.dart';
 void main() {
   test('==, hashCode, copyWith basics', () {
     expect(
-      const ScrollbarThemeData(),
-      const ScrollbarThemeData().copyWith(),
+      const MacosScrollbarThemeData(),
+      const MacosScrollbarThemeData().copyWith(),
     );
     expect(
-      const ScrollbarThemeData().hashCode,
-      const ScrollbarThemeData().copyWith().hashCode,
+      const MacosScrollbarThemeData().hashCode,
+      const MacosScrollbarThemeData().copyWith().hashCode,
     );
   });
 
   test('lerps from light to dark', () {
-    final actual = ScrollbarThemeData.lerp(
+    final actual = MacosScrollbarThemeData.lerp(
       _scrollbarThemeData,
       _scrollbarThemeDataDark,
       1,
@@ -26,7 +26,7 @@ void main() {
   });
 
   test('lerps from dark to light', () {
-    final actual = ScrollbarThemeData.lerp(
+    final actual = MacosScrollbarThemeData.lerp(
       _scrollbarThemeDataDark,
       _scrollbarThemeData,
       1,
@@ -38,7 +38,7 @@ void main() {
   //FIXME: Why does this pass??
   testWidgets('debugFillProperties', (tester) async {
     final builder = DiagnosticPropertiesBuilder();
-    const ScrollbarThemeData().debugFillProperties(builder);
+    const MacosScrollbarThemeData().debugFillProperties(builder);
 
     final description = builder.properties
         .where((node) => !node.isFiltered(DiagnosticLevel.info))
@@ -52,7 +52,7 @@ void main() {
   });
 }
 
-final _scrollbarThemeData = ScrollbarThemeData(
+final _scrollbarThemeData = MacosScrollbarThemeData(
   draggingThumbColor: Colors.grey.shade600,
   hoveringThumbColor: Colors.grey.shade600,
   hoveringTrackBorderColor: Colors.grey.shade600,
@@ -62,7 +62,7 @@ final _scrollbarThemeData = ScrollbarThemeData(
   trackColor: Colors.grey.shade600,
 );
 
-final _scrollbarThemeDataDark = ScrollbarThemeData(
+final _scrollbarThemeDataDark = MacosScrollbarThemeData(
   draggingThumbColor: Colors.grey.shade300,
   hoveringThumbColor: Colors.grey.shade300,
   hoveringTrackBorderColor: Colors.grey.shade300,


### PR DESCRIPTION
This PR contains version 1.4 of `macos_ui` with the following changes:

* Migration to Flutter 3.0
  * Minimum dart sdk version is now 2.17.0
  * Use new super parameters feature
  * Update to `flutter_lints: ^2.0.1` with subsequent fixes
  * `MacosScrollbar` API more closely matches its material counterpart 
* Update `MacosColor` to more closely match the `Color` class
  * Adds `MacosColor.fromARGB` constructor
  * Adds `MacosColor.fromRGBO` constructor
  * Adds `alphaBlend` function
  * Adds `getAlphaFromOpacity` function

Closes #247 

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->