### PR TITLE
remove setState call in the ResizablePane didUpdateWidget method

### DIFF
--- a/lib/src/layout/resizable_pane.dart
+++ b/lib/src/layout/resizable_pane.dart
@@ -164,10 +164,8 @@ class _ResizablePaneState extends State<ResizablePane> {
         oldWidget.minWidth != widget.minWidth ||
         oldWidget.maxWidth != widget.maxWidth ||
         oldWidget.resizableSide != widget.resizableSide) {
-      setState(() {
-        if (widget.minWidth > _width) _width = widget.minWidth;
-        if (widget.maxWidth < _width) _width = widget.maxWidth;
-      });
+      if (widget.minWidth > _width) _width = widget.minWidth;
+      if (widget.maxWidth < _width) _width = widget.maxWidth;
     }
   }
 


### PR DESCRIPTION
Removing as documentation states, that after didUpdateWidget is called, setState is also called.

The call is therefore unnecessary and should be removed.