### PR TITLE
Expand remaining part of row in MacosListTile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.4.2]
+* Fixes RenderFlex overflowed in `MacosListTile` [#264](https://github.com/GroovinChip/macos_ui/issues/264) 
+
 ## [1.4.1+1]
 * Update `pubspec.yaml` with `repository` and new `homepage` field.
 

--- a/lib/src/layout/macos_list_tile.dart
+++ b/lib/src/layout/macos_list_tile.dart
@@ -51,26 +51,30 @@ class MacosListTile extends StatelessWidget {
           children: [
             if (leading != null) leading!,
             SizedBox(width: leadingWhitespace),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                DefaultTextStyle(
-                  style: MacosTheme.of(context).typography.headline.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                  child: title,
-                ),
-                if (subtitle != null)
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
                   DefaultTextStyle(
-                    style:
-                        MacosTheme.of(context).typography.subheadline.copyWith(
-                              color: MacosTheme.brightnessOf(context).isDark
-                                  ? MacosColors.systemGrayColor
-                                  : const MacosColor(0xff88888C),
-                            ),
-                    child: subtitle!,
+                    style: MacosTheme.of(context).typography.headline.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
+                    child: title,
                   ),
-              ],
+                  if (subtitle != null)
+                    DefaultTextStyle(
+                      style: MacosTheme.of(context)
+                          .typography
+                          .subheadline
+                          .copyWith(
+                            color: MacosTheme.brightnessOf(context).isDark
+                                ? MacosColors.systemGrayColor
+                                : const MacosColor(0xff88888C),
+                          ),
+                      child: subtitle!,
+                    ),
+                ],
+              ),
             ),
           ],
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.4.1+1
+version: 1.4.2
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
<!--

    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioninig issues related to this pull request

-->
Fix RenderFlex overflowed in `MacosListTile` when text is long.

Fixes https://github.com/GroovinChip/macos_ui/issues/264.

<img width="678" alt="Screenshot 2022-06-20 at 7 04 30 PM" src="https://user-images.githubusercontent.com/1572333/174591481-d3a528a6-2177-4def-9a1f-57076849f590.png">



## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [ ] I have run "optimize/organize imports" on all changed files
- [ ] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->