### PR TITLE
fix: Correct the placement of the leading widget in disclosure sidebar items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.5.1]
+* Correct the placement of the leading widget in disclosure sidebar items [#268](https://github.com/GroovinChip/macos_ui/issues/268)
+
 ## [1.5.0]
 * Adds `endSidebar` to `MacosWindow`
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -188,6 +188,7 @@ class _WidgetGalleryState extends State<WidgetGallery> {
                   label: Text('Fields'),
                 ),
                 SidebarItem(
+                  leading: Icon(CupertinoIcons.folder),
                   label: Text('Disclosure'),
                   disclosureItems: [
                     SidebarItem(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.5.0"
+    version: "1.5.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -338,20 +338,21 @@ class __DisclosureSidebarItemState extends State<_DisclosureSidebarItem>
               label: widget.item.label,
               leading: Row(
                 children: [
-                  if (widget.item.leading != null)
-                    Padding(
-                      padding: EdgeInsets.only(right: spacing),
-                      child: widget.item.leading!,
-                    ),
                   RotationTransition(
                     turns: _iconTurns,
                     child: Icon(
                       CupertinoIcons.chevron_right,
+                      size: 12.0,
                       color: theme.brightness == Brightness.light
                           ? MacosColors.black
                           : MacosColors.white,
                     ),
                   ),
+                  if (widget.item.leading != null)
+                    Padding(
+                      padding: EdgeInsets.only(left: spacing),
+                      child: widget.item.leading!,
+                    ),
                 ],
               ),
               unselectedColor: MacosColors.transparent,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.5.0
+version: 1.5.1
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
This PR corrects the placement of the leading widget in disclosure sidebar items.

Closes #268 

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->