### PR TITLE
Tab view padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.7.0+1]
+## [1.7.2]
 * Add padding as parameter to MacosTabView constructor.
 
 ## [1.7.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.7.0+1]
+* Add padding as parameter to MacosTabView constructor.
+
 ## [1.7.0]
 * ✨ New
   * `MacosImageIcon` widget. Identical to the `ImageIcon` from `flutter/widgets.dart` except it will obey a 

--- a/lib/src/layout/tab_view/tab_view.dart
+++ b/lib/src/layout/tab_view/tab_view.dart
@@ -61,7 +61,9 @@ class MacosTabView extends StatefulWidget {
   /// The placement of the [tabs], typically [MacosTabPosition.top].
   final MacosTabPosition position;
 
-  ///The padding of the tab view widget
+  /// The padding of the tab view widget.
+  ///
+  /// Defaults to `EdgeInsets.all(12.0)`.
   final EdgeInsetsGeometry padding;
 
   @override

--- a/lib/src/layout/tab_view/tab_view.dart
+++ b/lib/src/layout/tab_view/tab_view.dart
@@ -43,6 +43,7 @@ class MacosTabView extends StatefulWidget {
     required this.tabs,
     required this.children,
     this.position = MacosTabPosition.top,
+    this.padding = const EdgeInsets.all(12.0),
   }) : assert(controller.length == children.length &&
             controller.length == tabs.length);
 
@@ -59,6 +60,9 @@ class MacosTabView extends StatefulWidget {
 
   /// The placement of the [tabs], typically [MacosTabPosition.top].
   final MacosTabPosition position;
+
+  ///The padding of the tab view widget
+  final EdgeInsetsGeometry padding;
 
   @override
   State<MacosTabView> createState() => _MacosTabViewState();
@@ -153,7 +157,7 @@ class _MacosTabViewState extends State<MacosTabView> {
       alignment: Alignment.center,
       children: [
         Padding(
-          padding: const EdgeInsets.all(12.0),
+          padding: widget.padding,
           child: DecoratedBox(
             decoration: BoxDecoration(
               color: brightness.resolve(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.7.0+1
+version: 1.7.2
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.7.0
+version: 1.7.0+1
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
<!--
    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioning issues related to this pull request

-->

I add padding parameter to MacosTabView to allow setting custom.
I am using macos_ui package in one of my apps and the default padding impact the ui.
here is a screenshot of the app with the MacosTabView with the default padding and a DataTable as one of children
![MacosTabView with default padding](https://user-images.githubusercontent.com/77164238/180391210-d7bf2db8-dc2f-4f41-8c7f-3c588760026b.png)


And here is the same app with custom padding

 
![MacosTabView](https://user-images.githubusercontent.com/77164238/180390042-dba20ba6-c0d6-4e6b-a3ff-fcce8988db72.png)


## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could