### PR TITLE
fix: use prepared title wrapped with a DefaultTextStyle instead of the raw title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.7.3]
+* Fixed an issue where the `title` property of `TitleBar` did not apply a fitting `DefaultTextStyle`
+
 ## [1.7.1]
 * Fixed an issue where end sidebar window breakpoints were not respected
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.1"
+    version: "1.7.3"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/title_bar.dart
+++ b/lib/src/layout/title_bar.dart
@@ -120,7 +120,7 @@ class TitleBar extends StatelessWidget {
               gradient: decoration?.gradient,
             ),
             child: NavigationToolbar(
-              middle: title,
+              middle: _title,
               centerMiddle: centerTitle,
               middleSpacing: 8,
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.7.1
+version: 1.7.3
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Fixes a typo where the `TitleBar`s `build`method does not use the prepared `title` wrapped with a `DefaultTextStyle` which leads to unintended visual appearance.


<!--

    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioning issues related to this pull request

-->

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->