### PR TITLE
fix: address ScrollController bug in MacosPopupButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## [1.7.6]
+* Fixed a bug where `MacosPopupButton` would report that a `ScrollController` was not attached to any views
+
 ## [1.7.5]
-* Address Flutter 3.3 analyzer warnings
+* Addressed Flutter 3.3 analyzer warnings
 
 ## [1.7.4]
 * Added `backgroundColor` to `MacosSheet`
@@ -8,7 +11,7 @@
 * Fixed an issue where the `title` property of `TitleBar` did not apply a fitting `DefaultTextStyle`
 
 ## [1.7.2]
-* Add padding as parameter to MacosTabView constructor.
+* Added padding as parameter to MacosTabView constructor.
 
 ## [1.7.1]
 * Fixed an issue where end sidebar window breakpoints were not respected

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -14,7 +14,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/macos_ui/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
+  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
   macos_ui: 125c911559d646194386d84c017ad6819122e2db
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.5"
+    version: "1.7.6"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/buttons/popup_button.dart
+++ b/lib/src/buttons/popup_button.dart
@@ -222,6 +222,7 @@ class _MacosPopupMenuState<T> extends State<_MacosPopupMenu<T>> {
         brightness.resolve(CupertinoColors.black, CupertinoColors.white);
 
     final itemsList = ListView.builder(
+      controller: widget.route.scrollController,
       itemCount: children.length,
       itemBuilder: (context, index) {
         return children[index];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.7.5
+version: 1.7.6
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Closes #297 

This also addresses the failing tests.

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->