### PR TITLE
Fix bug when transitioning from no sidebar to having sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.7]
+* Fixed a bug where transitioning from having `MacosWindow.sidebar` null to having an actual `Sidebar` instance
+would throw a null check error.
+
 ## [1.7.6]
 * Fixed a bug where `MacosPopupButton` would report that a `ScrollController` was not attached to any views
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -80,7 +80,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.7.6"
+    version: "1.7.7"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/window.dart
+++ b/lib/src/layout/window.dart
@@ -95,8 +95,8 @@ class _MacosWindowState extends State<MacosWindow> {
     setState(() {
       if (widget.sidebar == null) {
         _sidebarWidth = 0.0;
-      } else if (widget.sidebar!.minWidth != old.sidebar!.minWidth ||
-          widget.sidebar!.maxWidth != old.sidebar!.maxWidth) {
+      } else if (widget.sidebar!.minWidth != old.sidebar?.minWidth ||
+          widget.sidebar!.maxWidth != old.sidebar?.maxWidth) {
         if (widget.sidebar!.minWidth > _sidebarWidth) {
           _sidebarWidth = widget.sidebar!.minWidth;
         }
@@ -106,8 +106,8 @@ class _MacosWindowState extends State<MacosWindow> {
       }
       if (widget.endSidebar == null) {
         _endSidebarWidth = 0.0;
-      } else if (widget.endSidebar!.minWidth != old.endSidebar!.minWidth ||
-          widget.endSidebar!.maxWidth != old.endSidebar!.maxWidth) {
+      } else if (widget.endSidebar!.minWidth != old.endSidebar?.minWidth ||
+          widget.endSidebar!.maxWidth != old.endSidebar?.maxWidth) {
         if (widget.endSidebar!.minWidth > _endSidebarWidth) {
           _endSidebarWidth = widget.endSidebar!.minWidth;
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.7.6
+version: 1.7.7
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Currently, when transitioning from having no sidebar on the screen to having it, the `_MacosWindowState.didUpdateWidget` throws a _Null check operator used on a null value_ error because `old.sidebar` is null.

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes
- [x] I have added/updated relevant documentation NOT NECESSARY
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->