### PR TITLE
docs(MacosApp): fix constructor docs error

### DIFF
--- a/lib/src/macos_app.dart
+++ b/lib/src/macos_app.dart
@@ -35,7 +35,7 @@ class MacosApp extends StatefulWidget {
   /// application is launched with an intent that specifies an otherwise
   /// unsupported route.
   ///
-  /// This class creates an instance of [WidgetsApp].
+  /// This class creates an instance of [CupertinoApp].
   ///
   /// The boolean arguments, [routes], and [navigatorObservers], must not be null.
   const MacosApp({


### PR DESCRIPTION
The docs currently and erroneously state that `MacosApp` creates an instance of `WidgetsApp`, which is incorrect. This PR fixes that error.

## Pre-launch Checklist

- [x] I have run `dartfmt` on all changed files <!-- THIS IS REQUIRED -->
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could
<!-- - [ ] I have run `flutter pub publish --dry-run` and addressed any warnings --> <!-- MAINTAINER ONLY -->