### PR TITLE
fix(SidebarItem): use theme's primary color instead of hardcoded value 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.12.1]
+* Fix SidebarItem's leading icons not respecting the theme's primary color
+
 ## [1.12.0]
 ✨ New widget: `SliverToolBar`
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.12.0"
+    version: "1.12.1"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -115,8 +115,8 @@ class SidebarItems extends StatelessWidget {
     assert(debugCheckHasMacosTheme(context));
     assert(currentIndex < _allItems.length);
     final theme = MacosTheme.of(context);
-    return IconTheme.merge(
-      data: const IconThemeData(size: 20),
+    return MacosIconTheme.merge(
+      data: const MacosIconThemeData(size: 20),
       child: _SidebarItemsConfiguration(
         selectedColor: selectedColor ?? theme.primaryColor,
         unselectedColor: unselectedColor ?? MacosColors.transparent,
@@ -288,7 +288,7 @@ class _SidebarItem extends StatelessWidget {
                       data: MacosIconThemeData(
                         color: selected
                             ? MacosColors.white
-                            : MacosColors.controlAccentColor,
+                            : theme.primaryColor,
                         size: itemSize.iconSize,
                       ),
                       child: item.leading!,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.12.0
+version: 1.12.1
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Closes #313 

## Pre-launch Checklist

- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could