### PR TITLE
When toolbar item is clicked, first pop the route and then call its callback - Fixes #346

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.12.2]
+* Fixed a bug where clicking on a overflowed toolbar item with a navigation callback wouldn't work ([#346](https://github.com/GroovinChip/macos_ui/issues/346)).
+
 ## [1.12.1+1]
 * Fixed a typo in the December abbreviation displayed in the `MacosDatePicker`.
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.12.1+1"
+    version: "1.12.2"
   matcher:
     dependency: transitive
     description:

--- a/lib/src/layout/toolbar/toolbar_overflow_menu_item.dart
+++ b/lib/src/layout/toolbar/toolbar_overflow_menu_item.dart
@@ -54,8 +54,8 @@ class _ToolbarOverflowMenuItemState extends State<ToolbarOverflowMenuItem> {
   }
 
   void _handleOnTap() {
-    widget.onPressed?.call();
     Navigator.pop(context);
+    widget.onPressed?.call();
   }
 
   bool get _isHighlighted => _isHovered || widget.isSelected == true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.12.1+1
+version: 1.12.2
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Fixes #346.

When an overflowed toolbar item was clicked, we used to **call its callback and then pop the menu route**. This caused the issue where, if the callback involved pushing to the navigation stack, **it was immediately popped** and not shown. 

Swapping the order (first pop the menu route and then call the callback) fixes this.

## Pre-launch Checklist

- [✅] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [✅] I have added/updated relevant documentation <!-- If relevant -->
- [✅] I have run "optimize/organize imports" on all changed files
- [✅] I have addressed all analyzer warnings as best I could