### PR TITLE
Fix: use the `sidebar` and `endSidebar` key parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.12.4]
+* Fixed a bug where the `Sidebar.key` parameter wasn't used so it was impossible to properly implement a tab bar in the sidebar
+
 ## [1.12.3]
 * Added support for `routerConfig` to `MacosApp.router`. ([#388](https://github.com/macosui/macos_ui/issues/388))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-## [1.12.4]
-* Fixed a bug where the `Sidebar.key` parameter wasn't used so it was impossible to properly implement a tab bar in the sidebar
+## [1.12.5]
+* Fixed a bug where the `Sidebar.key` parameter wasn't used, which caused certain layouts to be unachievable.
 
 ## [1.12.3]
 * Added support for `routerConfig` to `MacosApp.router`. ([#388](https://github.com/macosui/macos_ui/issues/388))

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.12.3"
+    version: "1.12.5"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.12.4
+version: 1.12.5
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.12.3
+version: 1.12.4
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
- pass sidebar key to the sidebar root widget (`AnimatedPositioned`)
- create a new sidebar `ScrollController` when the key is change

<!--

    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioning issues related to this pull request

-->

### Why?
It wasn't possible to properly implement a tab bar in sidebar. Because when I have a few tabs and on each tab I have a scroll view two scrolls are connected to one controller when I switch between tabs 

## Pre-launch Checklist

- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could