### PR TITLE
feat: Added support for `startWeekOnMonday` to `MacosDatePicker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [2.0.0-beta.3]
+✨ New ✨
+* Added support for `startWeekOnMonday` to `MacosDatePicker`.
+
 🛠️ Fixed 🛠️
 * Better UX of the click on the calendar elements in `MacosDatePicker`
 

--- a/lib/src/selectors/date_picker.dart
+++ b/lib/src/selectors/date_picker.dart
@@ -62,7 +62,9 @@ class MacosDatePicker extends StatefulWidget {
 
   /// Allows for changing the order of day headers in the graphical Date Picker
   /// to Mo, Tu, We, Th, Fr, Sa, Su.
-  ///
+  /// 
+  /// This is useful for internationalization purposes, as many countries begin their weeks on Mondays.
+  /// 
   /// Defaults to `false`.
   final bool? startWeekOnMonday;
 

--- a/test/selectors/date_picker_test.dart
+++ b/test/selectors/date_picker_test.dart
@@ -308,4 +308,96 @@ void main() {
       },
     );
   });
+
+  testWidgets(
+    'Graphical MacosDatePicker with "startWeekOnMonday" set to true shows Monday as the first day of the week',
+        (tester) async {
+      await tester.pumpWidget(
+        MacosApp(
+          home: MacosWindow(
+            child: MacosScaffold(
+              children: [
+                ContentArea(
+                  builder: (context, _) {
+                    return Center(
+                      child: MacosDatePicker(
+                        startWeekOnMonday: true,
+                        initialDate: DateTime.parse('2023-04-01'),
+                        onDateChanged: (date) {},
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final dayHeadersRow = find.byType(GridView).first;
+      final dayHeaders = find.descendant(
+        of: dayHeadersRow,
+        matching: find.byType(Text),
+      );
+      final firstWeekday = dayHeaders.first;
+      final firstWeekdayText = (firstWeekday.evaluate().first.widget as Text).data;
+      await tester.pumpAndSettle();
+
+      expect(firstWeekdayText, 'Mo');
+
+      final calendarGrid = find.byType(GridView).last;
+      final dayOffsetWidgets = find.descendant(
+        of: calendarGrid,
+        matching: find.byType(SizedBox),
+      );
+      final dayOffset = dayOffsetWidgets.evaluate().length;
+
+      expect(dayOffset, 5);
+    },
+  );
+
+  // Regression test due to invalid "firstDayOfWeekIndex" implementation in MaterialLocalizations
+  // issue: https://github.com/flutter/flutter/issues/122274
+  // TODO: remove this once the issue is fixed and test starts failing
+  testWidgets(
+    'Graphical MacosDatePicker still needs "startWeekOnMonday" to show Monday as the first day of the week, even when the locale is set to something other than "en_US"',
+        (tester) async {
+      await tester.pumpWidget(
+        MacosApp(
+          supportedLocales: const [
+            Locale('en', 'PL'),
+          ],
+          home: MacosWindow(
+            child: MacosScaffold(
+              children: [
+                ContentArea(
+                  builder: (context, _) {
+                    return Center(
+                      child: MacosDatePicker(
+                        startWeekOnMonday: true,
+                        initialDate: DateTime.parse('2023-04-01'),
+                        onDateChanged: (date) {},
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final dayHeadersRow = find.byType(GridView).first;
+      final dayHeaders = find.descendant(
+        of: dayHeadersRow,
+        matching: find.byType(Text),
+      );
+      final firstWeekday = dayHeaders.first;
+      final firstWeekdayText = (firstWeekday.evaluate().first.widget as Text).data;
+      await tester.pumpAndSettle();
+
+      // The result will be 'Tu' if the fix is no longer needed and can be removed
+      expect(firstWeekdayText, 'Mo');
+    },
+  );
 }


### PR DESCRIPTION
This is the first step in fulfilling all requests from https://github.com/macosui/macos_ui/issues/369.
I've added an optional parameter `startWeekOnMonday` which allows to render a calendar with Monday as a first day of the week. 

This is a temporary solution, because the need of this feature is caused by invalid implementation of `firstDayOfWeekIndex` in `flutter_localizations` package: https://github.com/flutter/flutter/issues/122274

## Pre-launch Checklist

- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [X] I have added/updated relevant documentation <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could