### PR TITLE
feat: Added support for `dateFormat` to `MacosDatePicker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [2.0.0-beta.3]
+✨ New ✨
+* Added support for `dateFormat` to `MacosDatePicker`.
+
 🛠️ Fixed 🛠️
 * Better UX of the click on the calendar elements in `MacosDatePicker`
 

--- a/README.md
+++ b/README.md
@@ -974,6 +974,18 @@ There are three styles of `MacosDatePickers`:
   calendar-like interface to select a date.
 * `combined`: provides both `textual` and `graphical` interfaces.
 
+You can also define the `dateFormat` to change the way dates are displayed in the textual interface.
+It takes a string of tokens (case-insensitive) and replaces them with their corresponding values.
+The following tokens are supported:
+* `D`: day of the month (1-31)
+* `DD`: day of the month (01-31)
+* `M`: month of the year (1-12)
+* `MM`: month of the year (01-12)
+* `YYYY`: year (0000-9999)
+* Any separator between tokens is preserved (e.g. `/`, `-`, `.`)
+
+The default format is `M/D/YYYY`. 
+
 Example usage:
 ```dart
 MacosDatePicker(

--- a/test/selectors/date_picker_test.dart
+++ b/test/selectors/date_picker_test.dart
@@ -83,6 +83,59 @@ void main() {
     );
 
     testWidgets(
+      'Textual MacosDatePicker renders the date with respect to "dateFormat" property',
+          (tester) async {
+        renderWidget(String dateFormat) => MacosApp(
+          home: MacosWindow(
+            disableWallpaperTinting: true,
+            child: MacosScaffold(
+              children: [
+                ContentArea(
+                  builder: (context, _) {
+                    return Center(
+                      child: MacosDatePicker(
+                        initialDate: DateTime.parse('2023-04-01'),
+                        onDateChanged: (date) {},
+                        dateFormat: dateFormat,
+                        style: DatePickerStyle.textual,
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+
+        getNthTextFromWidget(int index) => (find.byType(Text).at(index).evaluate().first.widget as Text).data as String;
+
+        await tester.pumpWidget(renderWidget('dd.mm.yyyy'));
+        String firstDateElement = getNthTextFromWidget(0);
+        expect(firstDateElement, '01');
+        String secondDateElement = getNthTextFromWidget(1);
+        expect(secondDateElement, '.');
+        String thirdDateElement = getNthTextFromWidget(2);
+        expect(thirdDateElement, '04');
+        String fourthDateElement = getNthTextFromWidget(3);
+        expect(fourthDateElement, '.');
+        String fifthDateElement = getNthTextFromWidget(4);
+        expect(fifthDateElement, '2023');
+
+        await tester.pumpWidget(renderWidget('yyyy-m-d'));
+        firstDateElement = getNthTextFromWidget(0);
+        expect(firstDateElement, '2023');
+        secondDateElement = getNthTextFromWidget(1);
+        expect(secondDateElement, '-');
+        thirdDateElement = getNthTextFromWidget(2);
+        expect(thirdDateElement, '4');
+        fourthDateElement = getNthTextFromWidget(3);
+        expect(fourthDateElement, '-');
+        fifthDateElement = getNthTextFromWidget(4);
+        expect(fifthDateElement, '1');
+      },
+    );
+
+    testWidgets(
       'Can select the date field element and change the value',
       (tester) async {
         final today = DateTime.now();


### PR DESCRIPTION
This is another feature from https://github.com/macosui/macos_ui/issues/369.
I've added an optional parameter `dateFormat` which allows to change the way dates are displayed in the textual interface.

## Pre-launch Checklist

- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [X] I have added/updated relevant documentation <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could