### PR TITLE
feat: Added support for `weekdayAbbreviations` and `monthAbbreviations` to `MacosDatePicker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [2.0.0-beta.3]
 ✨ New ✨
+* Added support for `weekdayAbbreviations` and `monthAbbreviations` to `MacosDatePicker`.
 * Added support for `dateFormat` to `MacosDatePicker`.
 * Added support for `startWeekOnMonday` to `MacosDatePicker`.
 

--- a/README.md
+++ b/README.md
@@ -974,6 +974,10 @@ There are three styles of `MacosDatePickers`:
   calendar-like interface to select a date.
 * `combined`: provides both `textual` and `graphical` interfaces.
 
+Localization of the time picker is supported by the `weekdayAbbreviations` and `monthAbbreviations` parameters (instead of e.g. standard `localizations.narrowWeekdays()` in order to match Apple's spec).
+* `weekdayAbbreviations` should be a list of 7 strings, one for each day of the week, starting with Sunday
+* `monthAbbreviations` should be a list of 12 strings, one for each month of the year, starting with January
+
 You can also define the `dateFormat` to change the way dates are displayed in the textual interface.
 It takes a string of tokens (case-insensitive) and replaces them with their corresponding values.
 The following tokens are supported:

--- a/lib/src/selectors/date_picker.dart
+++ b/lib/src/selectors/date_picker.dart
@@ -44,6 +44,31 @@ class MacosDatePicker extends StatefulWidget {
     this.style = DatePickerStyle.combined,
     required this.onDateChanged,
     this.initialDate,
+    // Use this to get the weekday abbreviations instead of
+    // localizations.narrowWeekdays() in order to match Apple's spec
+    this.weekdayAbbreviations = const [
+      'Su',
+      'Mo',
+      'Tu',
+      'We',
+      'Th',
+      'Fr',
+      'Sa',
+    ],
+    this.monthAbbreviations = const [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ],
     this.dateFormat,
     this.startWeekOnMonday,
   });
@@ -60,6 +85,12 @@ class MacosDatePicker extends StatefulWidget {
   ///
   /// Defaults to `DateTime.now()`.
   final DateTime? initialDate;
+
+  /// A list of 7 strings, one for each day of the week, starting with Sunday.
+  final List<String> weekdayAbbreviations;
+
+  /// A list of 12 strings, one for each month of the year, starting with January.
+  final List<String> monthAbbreviations;
 
   /// Changes the way dates are displayed in the textual interface.
   ///
@@ -398,7 +429,7 @@ class _MacosDatePickerState extends State<MacosDatePicker> {
                   children: [
                     Expanded(
                       child: Text(
-                        '${intToMonthAbbr(_selectedMonth)} $_selectedYear',
+                        '${widget.monthAbbreviations[_selectedMonth - 1]} $_selectedYear',
                         style: const TextStyle(
                           fontSize: 13.0,
                           fontWeight: FontWeight.w700,

--- a/lib/src/selectors/date_picker.dart
+++ b/lib/src/selectors/date_picker.dart
@@ -118,18 +118,6 @@ class MacosDatePicker extends StatefulWidget {
 }
 
 class _MacosDatePickerState extends State<MacosDatePicker> {
-  // Use this to get the weekday abbreviations instead of
-  // localizations.narrowWeekdays() in order to match Apple's spec
-  static const List<String> _narrowWeekdays = <String>[
-    'Su',
-    'Mo',
-    'Tu',
-    'We',
-    'Th',
-    'Fr',
-    'Sa',
-  ];
-
   final _today = DateTime.now();
   late final _initialDate = widget.initialDate ?? _today;
 
@@ -224,7 +212,7 @@ class _MacosDatePickerState extends State<MacosDatePicker> {
     }
 
     for (int i = firstDayOfWeekIndex; result.length < 7; i = (i + 1) % 7) {
-      final weekday = _narrowWeekdays[i];
+      final weekday = widget.weekdayAbbreviations[i];
       result.add(
         ExcludeSemantics(
           child: Center(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -59,37 +59,6 @@ Color iconLuminance(Color backgroundColor, bool isDark) {
   }
 }
 
-String intToMonthAbbr(int month) {
-  switch (month) {
-    case 1:
-      return 'Jan';
-    case 2:
-      return 'Feb';
-    case 3:
-      return 'Mar';
-    case 4:
-      return 'Apr';
-    case 5:
-      return 'May';
-    case 6:
-      return 'Jun';
-    case 7:
-      return 'Jul';
-    case 8:
-      return 'Aug';
-    case 9:
-      return 'Sep';
-    case 10:
-      return 'Oct';
-    case 11:
-      return 'Nov';
-    case 12:
-      return 'Dec';
-    default:
-      throw Exception('Unsupported value');
-  }
-}
-
 class Unsupported {
   const Unsupported(this.message);
 

--- a/test/selectors/date_picker_test.dart
+++ b/test/selectors/date_picker_test.dart
@@ -360,6 +360,66 @@ void main() {
         }
       },
     );
+
+    testWidgets(
+      'Graphical MacosDatePicker renders abbreviations based on "weekdayAbbreviations" and "monthAbbreviations" properties',
+          (tester) async {
+        await tester.pumpWidget(
+          MacosApp(
+            home: MacosWindow(
+              child: MacosScaffold(
+                children: [
+                  ContentArea(
+                    builder: (context, _) {
+                      return Center(
+                        child: MacosDatePicker(
+                          initialDate: DateTime.parse('2023-04-01'),
+                          onDateChanged: (date) {},
+                          weekdayAbbreviations: const [
+                            'Nd',
+                            'Po',
+                            'Wt',
+                            'Śr',
+                            'Cz',
+                            'Pt',
+                            'So',
+                          ],
+                          monthAbbreviations: const [
+                            'Sty',
+                            'Lut',
+                            'Mar',
+                            'Kwi',
+                            'Maj',
+                            'Cze',
+                            'Lip',
+                            'Sie',
+                            'Wrz',
+                            'Paź',
+                            'Lis',
+                            'Gru',
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Kwi 2023'), findsOneWidget);
+        expect(find.text('Nd'), findsOneWidget);
+        expect(find.text('Po'), findsOneWidget);
+        expect(find.text('Wt'), findsOneWidget);
+        expect(find.text('Śr'), findsOneWidget);
+        expect(find.text('Cz'), findsOneWidget);
+        expect(find.text('Pt'), findsOneWidget);
+        expect(find.text('So'), findsOneWidget);
+      },
+    );
   });
 
   testWidgets(


### PR DESCRIPTION
This is another feature from https://github.com/macosui/macos_ui/issues/369.
I've added an optional `weekdaysAbbreviations` and `monthsAbbreviations` parameters. They allow to change the default English abbreviations in `MacosDatePicker`.

## Pre-launch Checklist

- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [X] I have added/updated relevant documentation <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could