### PR TITLE
fix: UX of the click on the calendar elements in `MacosDatePicker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.0-beta.3]
+🛠️ Fixed 🛠️
+* Better UX of the click on the calendar elements in `MacosDatePicker`
+
 ## [2.0.0-beta.2]
 ✨New ✨
 * `MacosSwitch` has been completely rewritten and now matches the native macOS switch in appearance and behavior.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -97,7 +97,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0-beta.2"
+    version: "2.0.0-beta.3"
   macos_window_utils:
     dependency: transitive
     description:

--- a/lib/src/selectors/date_picker.dart
+++ b/lib/src/selectors/date_picker.dart
@@ -526,6 +526,7 @@ class _MacosDatePickerState extends State<MacosDatePicker> {
         }
 
         Widget dayWidget = GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTap: () {
             setState(() {
               _isDaySelected = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.0.0-beta.2
+version: 2.0.0-beta.3
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Fixed UX of the click on the calendar elements in `MacosDatePicker`. 
User was able to trigger selection when they clicked on `Text` widget (green highlight), and all paddings inside `Container` widget were ignored (red highlight). So it was difficult to click on the small, hard-to-reach box with the cursor for the first 9 days of the month.
![CleanShot 2023-04-19 at 00 05 17](https://user-images.githubusercontent.com/34719093/232915612-879761e8-c569-48b7-8669-0f74bbc48e39.png)


## Pre-launch Checklist

- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could