### PR TITLE
Fix EnumProperty test.

### DIFF
--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -759,7 +759,7 @@ class MacosTextField extends StatefulWidget {
       'clearButtonMode',
       clearButtonMode,
     ));
-    properties.add(EnumProperty<TextInputType>(
+    properties.add(DiagnosticsProperty<TextInputType>(
       'keyboardType',
       keyboardType,
       defaultValue: TextInputType.text,


### PR DESCRIPTION
I'm changing `EnumProperty` to require an `Enum` and your test still uses a class. In Flutter, it went to DiagnosticsProperty, which is what I'm doing here.

<img width="685" alt="image" src="https://user-images.githubusercontent.com/351125/234925418-5641e68c-756a-4f41-ac95-20b4a963a049.png">

Related: https://github.com/flutter/flutter/pull/125016