### PR TITLE
Allow custom CupertinoThemeData, and some flexibility of Alerts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.12.3]
+* Allows specifying the CupertinoThemeData.
+* macOS alerts can be shown without a badge/icon.
+
 ## [1.12.2]
 * Fixed a bug where clicking on a overflowed toolbar item with a navigation callback wouldn't work ([#346](https://github.com/GroovinChip/macos_ui/issues/346)).
 

--- a/lib/src/dialogs/macos_alert_dialog.dart
+++ b/lib/src/dialogs/macos_alert_dialog.dart
@@ -14,9 +14,6 @@ const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 /// showMacosAlertDialog(
 ///    context: context,
 ///    builder: (_) => MacosAlertDialog(
-///     appIcon: FlutterLogo(
-///       size: 56,
-///     ),
 ///     title: Text(
 ///       'Alert Dialog with Primary Action',
 ///     ),
@@ -28,6 +25,9 @@ const _kDialogBorderRadius = BorderRadius.all(Radius.circular(12.0));
 ///       child: Text('Primary'),
 ///       onPressed: Navigator.of(context).pop,
 ///     ),
+///     appIcon: FlutterLogo(
+///       size: 56,
+///     ),
 ///   ),
 /// ),
 /// ```
@@ -35,10 +35,10 @@ class MacosAlertDialog extends StatelessWidget {
   /// Builds a macOS-style Alert Dialog
   const MacosAlertDialog({
     super.key,
-    required this.appIcon,
     required this.title,
-    required this.message,
     required this.primaryButton,
+    this.message,
+    this.appIcon,
     this.secondaryButton,
     this.horizontalActions = true,
     this.suppress,
@@ -47,7 +47,7 @@ class MacosAlertDialog extends StatelessWidget {
   /// This should be your application's icon.
   ///
   /// The size of this widget should be 56x56.
-  final Widget appIcon;
+  final Widget? appIcon;
 
   /// The title for the dialog.
   ///
@@ -57,7 +57,7 @@ class MacosAlertDialog extends StatelessWidget {
   /// The content to display in the dialog.
   ///
   /// Typically a Text widget.
-  final Widget message;
+  final Widget? message;
 
   /// The primary action a user can take.
   ///
@@ -159,26 +159,30 @@ class MacosAlertDialog extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const SizedBox(height: 28),
-              ConstrainedBox(
-                constraints: const BoxConstraints(
-                  maxHeight: 56,
-                  maxWidth: 56,
+              if (appIcon != null) ...[
+                const SizedBox(height: 28),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxHeight: 56,
+                    maxWidth: 56,
+                  ),
+                  child: appIcon,
                 ),
-                child: appIcon,
-              ),
+              ],
               const SizedBox(height: 28),
               DefaultTextStyle(
                 style: MacosTheme.of(context).typography.headline,
                 textAlign: TextAlign.center,
                 child: title,
               ),
-              const SizedBox(height: 16),
-              DefaultTextStyle(
-                textAlign: TextAlign.center,
-                style: MacosTheme.of(context).typography.headline,
-                child: message,
-              ),
+              if (message != null) ...[
+                const SizedBox(height: 16),
+                DefaultTextStyle(
+                  textAlign: TextAlign.center,
+                  style: MacosTheme.of(context).typography.headline,
+                  child: message!,
+                ),
+              ],
               const SizedBox(height: 18),
               if (secondaryButton == null) ...[
                 Row(

--- a/lib/src/macos_app.dart
+++ b/lib/src/macos_app.dart
@@ -71,6 +71,7 @@ class MacosApp extends StatefulWidget {
     this.themeMode,
     this.theme,
     this.darkTheme,
+    this.cupertinoThemeData,
   })  : routeInformationProvider = null,
         routeInformationParser = null,
         routerDelegate = null,
@@ -104,6 +105,7 @@ class MacosApp extends StatefulWidget {
     this.themeMode,
     this.theme,
     this.darkTheme,
+    this.cupertinoThemeData,
   })  : assert(supportedLocales.isNotEmpty),
         navigatorObservers = null,
         navigatorKey = null,
@@ -295,6 +297,9 @@ class MacosApp extends StatefulWidget {
   /// The style used if [themeMode] is [ThemeMode.light]
   final MacosThemeData? theme;
 
+  /// The cupertino themedata
+  final c.CupertinoThemeData? cupertinoThemeData;
+
   @override
   State<MacosApp> createState() => _MacosAppState();
 }
@@ -366,6 +371,7 @@ class _MacosAppState extends State<MacosApp> {
         shortcuts: widget.shortcuts,
         actions: widget.actions,
         scrollBehavior: widget.scrollBehavior,
+        theme: widget.cupertinoThemeData,
       );
     }
     return c.CupertinoApp(
@@ -395,6 +401,7 @@ class _MacosAppState extends State<MacosApp> {
       shortcuts: widget.shortcuts,
       actions: widget.actions,
       scrollBehavior: widget.scrollBehavior,
+      theme: widget.cupertinoThemeData,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 1.12.2
+version: 1.12.3
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Dear macOS-ui team, 

I needed to be able to toggle darkmode and light mode, which meant propagating the CupertinoThemeData.

I've also allowed some more flexibility in the alerts. 

Attached, video in action! 

https://github.com/macosui/macos_ui/assets/19474610/aa699488-076d-4013-b6a2-bdcce4059bd2


