### PR TITLE
Expose NSWindow Callbacks for Enhanced Window Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.0.3]
+### ✨ New ✨
+- Exposed the following NSWindow event callbacks via input parameters:
+  - `onWindowDidBecomeMain`
+  - `onWindowDidResignMain`
+  - `onWindowDidBecomeKey`
+  - `onWindowDidResignKey`
+  - `onWindowDidChangeScreen`
+  - `onWindowDidMove`
+  - `onWindowDidResize`
+
 ## [2.0.0]
 ### 🚨 Breaking Changes 🚨
 * `macos_ui` has been migrated to utilize [macos_window_utils](https://pub.dev/packages/macos_window_utils) under the hood, which provides the following benefits:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,29 @@ import 'theme.dart';
 
 /// This method initializes macos_window_utils and styles the window.
 Future<void> _configureMacosWindowUtils() async {
-  const config = MacosWindowUtilsConfig();
+  final config = MacosWindowUtilsConfig(
+    onWindowDidBecomeMain: () {
+      debugPrint('onWindowDidBecomeMain');
+    },
+    onWindowDidResignMain: () {
+      debugPrint('onWindowDidResignMain');
+    },
+    onWindowDidBecomeKey: () {
+      debugPrint('onWindowDidBecomeKey');
+    },
+    onWindowDidResignKey: () {
+      debugPrint('onWindowDidResignKey');
+    },
+    onWindowDidMove: () {
+      debugPrint('onWindowDidMove');
+    },
+    onWindowDidChangeScreen: () {
+      debugPrint('onWindowDidChangeScreen');
+    },
+    onWindowDidResize: () {
+      debugPrint('onWindowDidResize');
+    },
+  );
   await config.apply();
 }
 

--- a/lib/src/macos_window_utils_config.dart
+++ b/lib/src/macos_window_utils_config.dart
@@ -26,6 +26,13 @@ class MacosWindowUtilsConfig {
     this.hideTitle = true,
     this.removeMenubarInFullScreenMode = true,
     this.autoHideToolbarAndMenuBarInFullScreenMode = true,
+    this.onWindowDidBecomeMain,
+    this.onWindowDidResignMain,
+    this.onWindowDidBecomeKey,
+    this.onWindowDidResignKey,
+    this.onWindowDidChangeScreen,
+    this.onWindowDidMove,
+    this.onWindowDidResize,
   });
 
   /// The style of the window toolbar.
@@ -48,6 +55,27 @@ class MacosWindowUtilsConfig {
 
   /// Whether to automatically hide the toolbar and menubar in full-screen mode.
   final bool autoHideToolbarAndMenuBarInFullScreenMode;
+
+  /// Exposes the [onWindowDidBecomeMain] event
+  final VoidCallback? onWindowDidBecomeMain;
+
+  /// Exposes the [onWindowDidResignMain] event
+  final VoidCallback? onWindowDidResignMain;
+
+  /// Exposes the [onWindowDidBecomeKey] event
+  final VoidCallback? onWindowDidBecomeKey;
+
+  /// Exposes the [onWindowDidResignKey] event
+  final VoidCallback? onWindowDidResignKey;
+
+  /// Exposes the [onWindowDidChangeScreen] event
+  final VoidCallback? onWindowDidChangeScreen;
+
+  /// Exposes the [onWindowDidMove] event
+  final VoidCallback? onWindowDidMove;
+
+  /// Exposes the [onWindowDidResize] event
+  final VoidCallback? onWindowDidResize;
 
   /// Applies the configuration to the macOS window.
   ///
@@ -88,7 +116,15 @@ class MacosWindowUtilsConfig {
     );
 
     if (removeMenubarInFullScreenMode) {
-      final delegate = _FlutterWindowDelegate();
+      final delegate = _FlutterWindowDelegate(
+        onWindowDidBecomeMain: onWindowDidBecomeMain,
+        onWindowDidResignMain: onWindowDidResignMain,
+        onWindowDidBecomeKey: onWindowDidBecomeKey,
+        onWindowDidResignKey: onWindowDidResignKey,
+        onWindowDidChangeScreen: onWindowDidChangeScreen,
+        onWindowDidMove: onWindowDidMove,
+        onWindowDidResize: onWindowDidResize,
+      );
       WindowManipulator.addNSWindowDelegate(delegate);
     }
 
@@ -106,6 +142,24 @@ class MacosWindowUtilsConfig {
 
 /// This delegate removes the toolbar in full-screen mode.
 class _FlutterWindowDelegate extends NSWindowDelegate {
+  final VoidCallback? onWindowDidBecomeMain;
+  final VoidCallback? onWindowDidResignMain;
+  final VoidCallback? onWindowDidBecomeKey;
+  final VoidCallback? onWindowDidResignKey;
+  final VoidCallback? onWindowDidChangeScreen;
+  final VoidCallback? onWindowDidMove;
+  final VoidCallback? onWindowDidResize;
+
+  _FlutterWindowDelegate({
+    this.onWindowDidBecomeMain,
+    this.onWindowDidResignMain,
+    this.onWindowDidBecomeKey,
+    this.onWindowDidResignKey,
+    this.onWindowDidChangeScreen,
+    this.onWindowDidMove,
+    this.onWindowDidResize,
+  });
+
   @override
   void windowWillEnterFullScreen() {
     WindowManipulator.removeToolbar();
@@ -116,5 +170,47 @@ class _FlutterWindowDelegate extends NSWindowDelegate {
   void windowDidExitFullScreen() {
     WindowManipulator.addToolbar();
     super.windowDidExitFullScreen();
+  }
+
+  @override
+  void windowDidBecomeMain() {
+    onWindowDidBecomeMain?.call();
+    super.windowDidBecomeMain();
+  }
+
+  @override
+  void windowDidResignMain() {
+    onWindowDidResignMain?.call();
+    super.windowDidResignMain();
+  }
+
+  @override
+  void windowDidBecomeKey() {
+    onWindowDidBecomeKey?.call();
+    super.windowDidBecomeKey();
+  }
+
+  @override
+  void windowDidResignKey() {
+    onWindowDidResignKey?.call();
+    super.windowDidResignKey();
+  }
+
+  @override
+  void windowDidChangeScreen() {
+    onWindowDidChangeScreen?.call();
+    super.windowDidChangeScreen();
+  }
+
+  @override
+  void windowDidMove() {
+    onWindowDidMove?.call();
+    super.windowDidMove();
+  }
+
+  @override
+  void windowDidResize() {
+    onWindowDidResize?.call();
+    super.windowDidResize();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.0.0
+version: 2.0.3
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
This PR proposes exposing several NSWindow event callbacks, such as `onWindowDidBecomeMain`, `onWindowDidResignMain`, `onWindowDidBecomeKey`, `onWindowDidResignKey`, `onWindowDidChangeScreen`, `onWindowDidMove`, and `onWindowDidResize`, to allow developers to leverage and customize window behavior better.

<!--

    Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
    Consider mentioning issues related to this pull request

-->

## Pre-launch Checklist

- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could