### PR TITLE
Fix `CapacityIndicator` doc images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.1]
+* Fixed `CapacityIndicator` documentation images
+
 ## [2.0.0]
 ### 🚨 Breaking Changes 🚨
 * `macos_ui` has been migrated to utilize [macos_window_utils](https://pub.dev/packages/macos_window_utils) under the hood, which provides the following benefits:

--- a/lib/src/indicators/capacity_indicators.dart
+++ b/lib/src/indicators/capacity_indicators.dart
@@ -19,7 +19,7 @@ const double _kCapacityIndicatorMinWidth = 100.0;
 /// to indicate the current value. Tick marks are often displayed
 /// to provide context.
 ///
-/// ![Continuous Capacity Indicator](https://developer.apple.com/design/human-interface-guidelines/macos/images/indicators-continous.png)
+/// ![Continuous Capacity Indicator](https://docs-assets.developer.apple.com/published/5b1ce5ce24fb7f819874616ea54c65eb/indicators-continuous~dark@2x.png)
 ///
 /// * Discrete
 ///
@@ -28,7 +28,7 @@ const double _kCapacityIndicatorMinWidth = 100.0;
 /// fill completely—never partially—with color to indicate the current
 /// value.
 ///
-/// ![Discrete Capacity Indicator](https://developer.apple.com/design/human-interface-guidelines/macos/images/indicators-discrete.png)
+/// ![Discrete Capacity Indicator](https://docs-assets.developer.apple.com/published/34f67e956ecd1cce97f01db966674bed/indicators-discrete~dark@2x.png)
 class CapacityIndicator extends StatelessWidget {
   /// Creates a capacity indicator.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.0.0
+version: 2.0.1
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
fixes [`CapacityIndicator` documentation images are not found](https://github.com/macosui/macos_ui/issues/474)

## Pre-launch Checklist

- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [ ] I have run "optimize/organize imports" on all changed files
- [ ] I have addressed all analyzer warnings as best I could