### PR TITLE
Replace ToolBar with PreferredSizeWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 🔄 Updated 🔄
 * `PushButton` has received a facelift. It now mimics the look and feel of native macOS buttons more closely.
   * **Note:** As a result, its `pressedOpacity` property and the `PushButtonTheme` class have been deprecated. 
+* The type of `MacosScaffold`'s `ToolBar` is now `PreferredSizeWidget`.
 
 ## [2.0.0]
 ### 🚨 Breaking Changes 🚨

--- a/example/lib/pages/buttons_page.dart
+++ b/example/lib/pages/buttons_page.dart
@@ -93,8 +93,8 @@ class _ButtonsPageState extends State<ButtonsPage> {
                             MaterialPageRoute(
                               builder: (_) {
                                 return MacosScaffold(
-                                  toolBar: const ToolBar(
-                                    title: Text('New page'),
+                                  toolBar: ToolBar(
+                                    title: const Text('New page'),
                                   ),
                                   children: [
                                     ContentArea(
@@ -137,8 +137,8 @@ class _ButtonsPageState extends State<ButtonsPage> {
                             MaterialPageRoute(
                               builder: (_) {
                                 return MacosScaffold(
-                                  toolBar: const ToolBar(
-                                    title: Text('New page'),
+                                  toolBar: ToolBar(
+                                    title: const Text('New page'),
                                   ),
                                   children: [
                                     ContentArea(
@@ -181,8 +181,8 @@ class _ButtonsPageState extends State<ButtonsPage> {
                             MaterialPageRoute(
                               builder: (_) {
                                 return MacosScaffold(
-                                  toolBar: const ToolBar(
-                                    title: Text('New page'),
+                                  toolBar: ToolBar(
+                                    title: const Text('New page'),
                                   ),
                                   children: [
                                     ContentArea(
@@ -271,8 +271,8 @@ class _ButtonsPageState extends State<ButtonsPage> {
                             MaterialPageRoute(
                               builder: (_) {
                                 return MacosScaffold(
-                                  toolBar: const ToolBar(
-                                    title: Text('New page'),
+                                  toolBar: ToolBar(
+                                    title: const Text('New page'),
                                   ),
                                   children: [
                                     ContentArea(
@@ -316,8 +316,8 @@ class _ButtonsPageState extends State<ButtonsPage> {
                             MaterialPageRoute(
                               builder: (_) {
                                 return MacosScaffold(
-                                  toolBar: const ToolBar(
-                                    title: Text('New page'),
+                                  toolBar: ToolBar(
+                                    title: const Text('New page'),
                                   ),
                                   children: [
                                     ContentArea(
@@ -361,8 +361,8 @@ class _ButtonsPageState extends State<ButtonsPage> {
                             MaterialPageRoute(
                               builder: (_) {
                                 return MacosScaffold(
-                                  toolBar: const ToolBar(
-                                    title: Text('New page'),
+                                  toolBar: ToolBar(
+                                    title: const Text('New page'),
                                   ),
                                   children: [
                                     ContentArea(

--- a/example/lib/pages/typography_page.dart
+++ b/example/lib/pages/typography_page.dart
@@ -19,8 +19,8 @@ class TypographyPage extends StatelessWidget {
     );
 
     return MacosScaffold(
-      toolBar: const ToolBar(
-        title: Text('Typography'),
+      toolBar: ToolBar(
+        title: const Text('Typography'),
       ),
       children: [
         ContentArea(

--- a/lib/src/layout/scaffold.dart
+++ b/lib/src/layout/scaffold.dart
@@ -30,7 +30,7 @@ class MacosScaffold extends StatefulWidget {
   final List<Widget> children;
 
   /// The [Toolbar] to use at the top of the layout scaffold.
-  final ToolBar? toolBar;
+  final PreferredSizeWidget? toolBar;
 
   @override
   State<MacosScaffold> createState() => _MacosScaffoldState();
@@ -73,7 +73,7 @@ class _MacosScaffoldState extends State<MacosScaffold> {
         final mediaQuery = MediaQuery.of(context);
         final children = widget.children;
         double topPadding = 0;
-        if (widget.toolBar != null) topPadding += widget.toolBar!.height;
+        if (widget.toolBar != null) topPadding += widget.toolBar!.preferredSize.height;
 
         return Stack(
           children: [
@@ -118,7 +118,7 @@ class _MacosScaffoldState extends State<MacosScaffold> {
             if (widget.toolBar != null)
               Positioned(
                 width: width,
-                height: widget.toolBar!.height,
+                height: widget.toolBar!.preferredSize.height,
                 child: widget.toolBar!,
               ),
           ],

--- a/lib/src/layout/toolbar/toolbar.dart
+++ b/lib/src/layout/toolbar/toolbar.dart
@@ -7,7 +7,7 @@ import 'package:macos_ui/src/layout/wallpaper_tinting_settings/wallpaper_tinting
 import 'package:macos_ui/src/library.dart';
 
 /// Defines the height of a regular-sized [ToolBar]
-const _kToolbarHeight = 52.0;
+const kToolbarHeight = 52.0;
 
 /// Defines the width of the leading widget in the [ToolBar]
 const _kLeadingWidth = 20.0;
@@ -16,7 +16,7 @@ const _kLeadingWidth = 20.0;
 const _kTitleWidth = 150.0;
 
 /// A toolbar to use in a [MacosScaffold].
-class ToolBar extends StatefulWidget with Diagnosticable {
+class ToolBar extends StatefulWidget with Diagnosticable implements PreferredSizeWidget {
   /// Creates a toolbar in the [MacosScaffold]. The toolbar appears below the
   /// title bar (if present) of the macOS app or integrates with it.
   ///
@@ -31,9 +31,9 @@ class ToolBar extends StatefulWidget with Diagnosticable {
   /// command of your app.
   ///
   /// The height of the ToolBar can be changed with [height].
-  const ToolBar({
+  ToolBar({
     super.key,
-    this.height = _kToolbarHeight,
+    this.height = kToolbarHeight,
     this.alignment = Alignment.center,
     this.title,
     this.titleWidth = _kTitleWidth,
@@ -46,7 +46,7 @@ class ToolBar extends StatefulWidget with Diagnosticable {
     this.dividerColor,
     this.allowWallpaperTintingOverrides = true,
     this.enableBlur = false,
-  });
+  }) : preferredSize = _PreferredToolbarSize(height);
 
   /// Specifies the height of this [ToolBar].
   ///
@@ -152,6 +152,12 @@ class ToolBar extends StatefulWidget with Diagnosticable {
   /// Whether this [ToolBar] should have a blur backdrop filter applied to it.
   final bool enableBlur;
 
+  /// Preferred toolBar's [height].
+  ///
+  /// [MacosScaffold] uses this size to set its app bar's height.
+  @override
+  final Size preferredSize;
+
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -179,6 +185,13 @@ class ToolBar extends StatefulWidget with Diagnosticable {
 
   @override
   State<ToolBar> createState() => _ToolBarState();
+}
+
+class _PreferredToolbarSize extends Size {
+  _PreferredToolbarSize(this.toolbarHeight)
+    : super.fromHeight((toolbarHeight ?? kToolbarHeight));
+
+  final double? toolbarHeight;
 }
 
 class _ToolBarState extends State<ToolBar> {

--- a/lib/src/layout/toolbar/toolbar.dart
+++ b/lib/src/layout/toolbar/toolbar.dart
@@ -152,9 +152,9 @@ class ToolBar extends StatefulWidget with Diagnosticable implements PreferredSiz
   /// Whether this [ToolBar] should have a blur backdrop filter applied to it.
   final bool enableBlur;
 
-  /// Preferred toolBar's [height].
+  /// Preferred [TooBar]'s [height].
   ///
-  /// [MacosScaffold] uses this size to set its app bar's height.
+  /// [MacosScaffold] uses this size to set its [ToolBar]'s height.
   @override
   final Size preferredSize;
 

--- a/test/buttons/back_button_test.dart
+++ b/test/buttons/back_button_test.dart
@@ -21,7 +21,7 @@ void main() {
         navigatorObservers: [
           navigatorObserver,
         ],
-        home: const MacosWindow(
+        home: MacosWindow(
           child: MacosScaffold(
             toolBar: ToolBar(
               leading: MacosBackButton(),


### PR DESCRIPTION
<!--
Add a concise description of what this PR is changing or adding, and why. Consider including before/after screenshots.
Consider mentioning issues related to this pull request
-->
### TL;DR
As per [SOLID](https://www.bmc.com/blogs/solid-design-principles/) principles, `MacOsScaffold`'s `toolBar` should be a `PreferredSizeWidget`.

### The longer story.
Hello guys, hope you are well. I was going to write an app for MacOS. I have adopted this amazing library. 
However, I have hit a wall with this scenario:
My `MainScreen` contains a `MacOsScaffold`, which contains a `ToolBar` and many children:
```dart
MacosScaffold(
    toolBar: const ToolBar(),
    children: [
        ...
    ],
);
```
My `ToolBar` has many options, conditions and buttons, so I would like to create a separate `Widget` to deal with those.
However, the `MacosScaffold` doesn't accept anything else that is not a `ToolBar`.

Other frameworks (e.g. `Material`) accepts a `PreferredSizeWidget`, which allows me to write
```dart
import 'package:macos_ui/macos_ui.dart'; //kToolbarHeight is now publicly available!

class MyToolbar extends StatelessWidget implements PreferredSizeWidget {
    @override
    Widget build(BuildContext context) {
        return ToolBar(
            actions: [
                ...
            ],
        )
    }

    @override
    Size get preferredSize => const Size.fromHeight(kToolbarHeight);
} 
```
And this solves my problem.

**BONUS:** this respect's Flutter's phylosophy of composition over inheritance.

## Pre-launch Checklist
- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could