### PR TITLE
Remove usages of '@image' directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.2]
+### 🛠️ Fixed 🛠️
+* Fixed images in generated documentation.
+
 ## [2.0.1]
 ### 🔄 Updated 🔄
 * `PushButton` has received a facelift. It now mimics the look and feel of native macOS buttons more closely.

--- a/lib/src/indicators/slider.dart
+++ b/lib/src/indicators/slider.dart
@@ -20,7 +20,6 @@ const double _kDiscreteThumbBorderRadius = 8;
 /// The slider doesn't maintain any state itself, instead the user is expected to
 /// update this widget with a new [value] whenever the slider changes.
 ///
-/// {@image <image src="https://developer.apple.com/design/human-interface-guidelines/images/intro/components/slider-intro-dark_2x.png" height="150"/>}
 /// {@endtemplate}
 class MacosSlider extends StatelessWidget {
   /// {@macro macosSlider}

--- a/lib/src/layout/sidebar/sidebar_item.dart
+++ b/lib/src/layout/sidebar/sidebar_item.dart
@@ -62,7 +62,7 @@ class SidebarItem with Diagnosticable {
   ///
   /// Typically a text indicator of a count of items, like in this
   /// screenshots from the Apple Notes app:
-  /// {@image <img src="https://imgur.com/REpW9f9.png" height="88" width="219" />}
+  /// <img src="https://imgur.com/REpW9f9.png" height="88" width="219" />
   final Widget? trailing;
 
   @override

--- a/lib/src/layout/tab_view/tab_view.dart
+++ b/lib/src/layout/tab_view/tab_view.dart
@@ -26,7 +26,7 @@ enum MacosTabPosition {
 /// {@template macosTabView}
 /// A multipage interface that displays one page at a time.
 ///
-/// {@image <image alt='' src='https://docs-assets.developer.apple.com/published/db00e4fdc8/tabview_2x_bf87676c-ac06-41f4-a430-0b95b43cd278.png' width='400' height='400'>}
+/// <image alt='' src='https://docs-assets.developer.apple.com/published/db00e4fdc8/tabview_2x_bf87676c-ac06-41f4-a430-0b95b43cd278.png' width='400' height='400' />
 ///
 /// A tab view contains a row of navigational items, [tabs], that move the
 /// user through the provided views ([children]). The user selects the desired

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.0.1
+version: 2.0.2
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
The `{@image` directive does not work, and images can just be specified with the HTML `img` tag. See how the docs currently look:

<img width="307" alt="Screenshot 2023-09-29 at 4 26 00 PM" src="https://github.com/macosui/macos_ui/assets/103167/f5cfc4f2-7bf1-4362-b0ad-befd920a95c2">

The MacosSlider image link is broken, so I just removed it.

## Pre-launch Checklist

- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [ ] I have added/updated relevant documentation <!-- If relevant -->
- [ ] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could