### PR TITLE
Adding initialTime parameter to MacosTimePicker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ metrics
 
 coverage_report
 coverage
+example/macos/Flutter/GeneratedPluginRegistrant.swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.3]
+### 🔄 Updated 🔄
+* Added `initialTime` parameter to `MacosTimePicker`, allowing to set an initial time for the picker.This provides more customization options for selecting time.
+
 ## [2.0.2]
 ### 🛠️ Fixed 🛠️
 * Fixed images in generated documentation.

--- a/lib/src/selectors/date_picker.dart
+++ b/lib/src/selectors/date_picker.dart
@@ -21,7 +21,7 @@ enum DatePickerStyle {
 /// {template onDateChanged}
 /// The action to perform when a new date is selected.
 /// {endtemplate}
-typedef OnDateChanged = Function(DateTime date);
+typedef OnDateChanged = void Function(DateTime date);
 
 /// {template macosDatePicker}
 /// A [MacosDatePicker] lets the user choose a date.

--- a/lib/src/selectors/time_picker.dart
+++ b/lib/src/selectors/time_picker.dart
@@ -20,8 +20,8 @@ enum TimePickerStyle {
 
 /// {template onTimeChanged}
 /// The action to perform when a new time is selected.
-/// {endtemplate}
-typedef OnTimeChanged = Function(TimeOfDay time);
+/// {end-template}
+typedef OnTimeChanged = void Function(TimeOfDay time);
 
 /// {template macosTimePicker}
 /// A [MacosTimePicker] lets the user choose a time.
@@ -36,14 +36,20 @@ typedef OnTimeChanged = Function(TimeOfDay time);
 ///
 /// The [onTimeChanged] callback passes through the user's selected time, and
 /// must be provided.
-/// {endtemplate}
+/// {end-template}
 class MacosTimePicker extends StatefulWidget {
   /// {@macro macosTimePicker}
   const MacosTimePicker({
     super.key,
     required this.onTimeChanged,
+    this.initialTime,
     this.style = TimePickerStyle.combined,
   });
+
+  /// Set an initial date for the picker.
+  ///
+  /// Defaults to `TimeOfDay.now()`.
+  final TimeOfDay? initialTime;
 
   /// The [TimePickerStyle] to use.
   ///
@@ -58,7 +64,7 @@ class MacosTimePicker extends StatefulWidget {
 }
 
 class _MacosTimePickerState extends State<MacosTimePicker> {
-  final _initialTime = TimeOfDay.now();
+  late final _initialTime = widget.initialTime ?? TimeOfDay.now();
   late int _selectedHour;
   late int _selectedMinute;
   late DayPeriod _selectedPeriod;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.0.2
+version: 2.0.3
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
I have added the `initialTime` parameter to the `MacosTimePicker` widget, allowing to set an initial time value for the picker.

**Minor Change**: Added a `void` return type to `OnDateChanged` and `OnTimeChanged`.

The change has been tested to ensure proper functionality.

### Checklist

- [x] Incremented the package version in `pubspec.yaml` (2.0.3).
- [x] Updated the `CHANGELOG.md`.
- [x] All code is properly formatted and comments are added.
- [x] Verified that there are no Dart analysis warnings.
- [x] Tested and confirmed that the changes work as expected.