### PR TITLE
Solve a problem start sidebar not close properly and black background Color.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.6]
+### 🛠️ Fixed 🛠️
+* Fixed `Sidebar` start sidebar not closing properly and fix black background Color.
+
 ## [2.0.5]
 ### 🛠️ Fixed 🛠️
 * Fixed `MacosRadioButton` check null value issue.


### PR DESCRIPTION
an issue on both web and Windows platforms:  The start sidebar not close properly, and black background color on both sidebars. This pull request aims to address and fix this problem.

### Changes Made:
- **Before Fix:**
  ![Before](https://github.com/macosui/macos_ui/assets/112737126/921a7318-2874-4a01-b865-ffbed29df895)
  
- **After Fix:**
  ![After](https://github.com/macosui/macos_ui/assets/112737126/152e0333-a03f-443f-b799-d4816fee9878)

### Affected Platforms:
- Web
- Windows

### Unverified Platform:
- macOS (not tested), I not think it affected.

### Pre-launch Checklist:

- [x] Incremented the package version and updated `CHANGELOG.md` with the changes <!-- REQUIRED -->
- [x] Added/updated relevant documentation <!-- If applicable -->
- [x] Addressed all analyzer warnings to the best of my ability
