### PR TITLE
Allow initial expansion of SidebarItem disclosure items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.9]
+### 🛠️ Updated 🛠️
+* Add `expandDisclosureItems` flag to `SidebarItem` to optionally (default not changed) expand disclosure items initially
+
 ## [2.0.8]
 ### 🛠️ Updated 🛠️
 * Fixed `SidebarItem` text overflowing.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -221,6 +221,7 @@ class _WidgetGalleryState extends State<WidgetGallery> {
                       label: Text('ResizablePane'),
                     ),
                   ],
+                  expandDisclosureItems: true,
                 ),
                 SidebarItem(
                   leading: MacosImageIcon(

--- a/lib/src/layout/sidebar/sidebar_item.dart
+++ b/lib/src/layout/sidebar/sidebar_item.dart
@@ -19,6 +19,7 @@ class SidebarItem with Diagnosticable {
     this.focusNode,
     this.semanticLabel,
     this.disclosureItems,
+    this.expandDisclosureItems = false,
     this.trailing,
   });
 
@@ -58,6 +59,11 @@ class SidebarItem with Diagnosticable {
   /// If non-null and [leading] is null, a local animated icon is created
   final List<SidebarItem>? disclosureItems;
 
+  /// If true, the disclosure items will be expanded otherwise collapsed.
+  ///
+  /// Defaults to false. There is no impact if [disclosureItems] is null.
+  final bool expandDisclosureItems;
+
   /// An optional trailing widget.
   ///
   /// Typically a text indicator of a count of items, like in this
@@ -77,6 +83,8 @@ class SidebarItem with Diagnosticable {
       'disclosure items',
       disclosureItems,
     ));
+    properties.add(
+        FlagProperty('expandDisclosureItems', value: expandDisclosureItems));
     properties.add(DiagnosticsProperty<Widget?>('trailing', trailing));
   }
 }

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -378,8 +378,7 @@ class __DisclosureSidebarItemState extends State<_DisclosureSidebarItem>
   late AnimationController _controller;
   late Animation<double> _iconTurns;
   late Animation<double> _heightFactor;
-
-  bool _isExpanded = false;
+  late bool _isExpanded;
 
   bool get hasLeading => widget.item.leading != null;
 
@@ -389,6 +388,11 @@ class __DisclosureSidebarItemState extends State<_DisclosureSidebarItem>
     _controller = AnimationController(duration: _kExpand, vsync: this);
     _heightFactor = _controller.drive(_easeInTween);
     _iconTurns = _controller.drive(_halfTween.chain(_easeInTween));
+
+    _isExpanded = widget.item.expandDisclosureItems;
+    if (_isExpanded) {
+      _controller.forward();
+    }
   }
 
   void _handleTap() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.0.8
+version: 2.0.9
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Add `expandDisclosureItems` flag to `SidebarItem` to optionally (default not changed) expand disclosure items initially

## Pre-launch Checklist

- [X] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [X] I have added/updated relevant documentation <!-- If relevant -->
- [X] I have run "optimize/organize imports" on all changed files
- [X] I have addressed all analyzer warnings as best I could