### PR TITLE
SidebarItems section header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.5]
+### 🔄 Updated 🔄
+* add `header` parameter to `SidebarItem` to display an unclickable widget in the sidebar as a section header.
+
 ## [2.1.4]
 ### 🛠️ Fixed 🛠️
 * Fix incorrect barrier color when calling `showMacosAlertDialog` when dark mode is enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [2.1.5]
 ### 🔄 Updated 🔄
-* add `header` parameter to `SidebarItem` to display an unclickable widget in the sidebar as a section header.
+* add `section` parameter to `SidebarItem` to display an unclickable widget in the sidebar as a section header.
 
 ## [2.1.4]
 ### 🛠️ Fixed 🛠️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [2.1.6]
 ### 🔄 Updated 🔄
-* add `section` parameter to `SidebarItem` to display an unclickable widget in the sidebar as a section header.
+* add `section` parameter to `SidebarItem` to display an unclickable widget in the sidebar as a section header (thanks, [@whirlun](https://github.com/whirlun)).
+* Fix incorrect barrier color when calling `showMacosSheet` when dark mode is enabled.
 
 ## [2.1.5]
 ### 🛻 Migrated 🛻

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -161,36 +161,45 @@ class _WidgetGalleryState extends State<WidgetGallery> {
               itemSize: SidebarItemSize.large,
               items: const [
                 SidebarItem(
-                  leading: MacosImageIcon(
-                    AssetImage('assets/sf_symbols/button_programmable_2x.png'),
-                  ),
-                  label: Text('Buttons'),
-                ),
-                SidebarItem(
-                  leading: MacosImageIcon(
-                    AssetImage(
-                      'assets/sf_symbols/lines_measurement_horizontal_2x.png',
+                  label: Text('Basic UI Elements'),
+                  section: true,
+                  expandDisclosureItems: true,
+                  disclosureItems: [
+                    SidebarItem(
+                      leading: MacosImageIcon(
+                        AssetImage(
+                            'assets/sf_symbols/button_programmable_2x.png'),
+                      ),
+                      label: Text('Buttons'),
                     ),
-                  ),
-                  label: Text('Indicators'),
-                ),
-                SidebarItem(
-                  leading: MacosImageIcon(
-                    AssetImage(
-                      'assets/sf_symbols/character_cursor_ibeam_2x.png',
+                    SidebarItem(
+                      leading: MacosImageIcon(
+                        AssetImage(
+                          'assets/sf_symbols/lines_measurement_horizontal_2x.png',
+                        ),
+                      ),
+                      label: Text('Indicators'),
                     ),
-                  ),
-                  label: Text('Fields'),
-                ),
-                SidebarItem(
-                  leading: MacosImageIcon(
-                    AssetImage('assets/sf_symbols/rectangle_3_group_2x.png'),
-                  ),
-                  label: Text('Colors'),
-                ),
-                SidebarItem(
-                  leading: MacosIcon(CupertinoIcons.square_on_square),
-                  label: Text('Dialogs & Sheets'),
+                    SidebarItem(
+                      leading: MacosImageIcon(
+                        AssetImage(
+                          'assets/sf_symbols/character_cursor_ibeam_2x.png',
+                        ),
+                      ),
+                      label: Text('Fields'),
+                    ),
+                    SidebarItem(
+                      leading: MacosImageIcon(
+                        AssetImage(
+                            'assets/sf_symbols/rectangle_3_group_2x.png'),
+                      ),
+                      label: Text('Colors'),
+                    ),
+                    SidebarItem(
+                      leading: MacosIcon(CupertinoIcons.square_on_square),
+                      label: Text('Dialogs & Sheets'),
+                    ),
+                  ],
                 ),
                 SidebarItem(
                   leading: MacosImageIcon(
@@ -199,6 +208,7 @@ class _WidgetGalleryState extends State<WidgetGallery> {
                     ),
                   ),
                   label: Text('Layout'),
+                  section: true,
                   disclosureItems: [
                     SidebarItem(
                       leading: MacosIcon(CupertinoIcons.macwindow),
@@ -224,15 +234,22 @@ class _WidgetGalleryState extends State<WidgetGallery> {
                   expandDisclosureItems: true,
                 ),
                 SidebarItem(
-                  leading: MacosImageIcon(
-                    AssetImage(
-                        'assets/sf_symbols/filemenu_and_selection_2x.png'),
-                  ),
-                  label: Text('Selectors'),
-                ),
-                SidebarItem(
-                  leading: MacosIcon(CupertinoIcons.textformat_size),
-                  label: Text('Typography'),
+                  label: Text('Additional UI Elements'),
+                  section: true,
+                  expandDisclosureItems: true,
+                  disclosureItems: [
+                    SidebarItem(
+                      leading: MacosImageIcon(
+                        AssetImage(
+                            'assets/sf_symbols/filemenu_and_selection_2x.png'),
+                      ),
+                      label: Text('Selectors'),
+                    ),
+                    SidebarItem(
+                      leading: MacosIcon(CupertinoIcons.textformat_size),
+                      label: Text('Typography'),
+                    ),
+                  ],
                 ),
               ],
             );

--- a/lib/src/layout/sidebar/sidebar_item.dart
+++ b/lib/src/layout/sidebar/sidebar_item.dart
@@ -21,6 +21,7 @@ class SidebarItem with Diagnosticable {
     this.disclosureItems,
     this.expandDisclosureItems = false,
     this.trailing,
+    this.section = false,
   });
 
   /// The widget before [label].
@@ -70,6 +71,9 @@ class SidebarItem with Diagnosticable {
   /// screenshots from the Apple Notes app:
   /// <img src="https://imgur.com/REpW9f9.png" height="88" width="219" />
   final Widget? trailing;
+
+  /// If true, this item is a section header.
+  final bool? section;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -151,6 +151,9 @@ class SidebarItems extends StatelessWidget {
                       EdgeInsets.all(10.0 - theme.visualDensity.horizontal),
                   children: List.generate(items.length, (index) {
                     final item = items[index];
+                    if (item.section == true) {
+                      return _SidebarHeaderItem(item: item);
+                    }
                     if (item.disclosureItems != null) {
                       return MouseRegion(
                         cursor: cursor!,
@@ -162,9 +165,6 @@ class SidebarItems extends StatelessWidget {
                           },
                         ),
                       );
-                    }
-                    if (item.section == true) {
-                      return _SidebarHeaderItem(item: item);
                     }
                     return MouseRegion(
                       cursor: cursor!,

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -431,7 +431,6 @@ class _SidebarItem extends StatelessWidget {
                   ),
                 ),
                 if (hasTrailing) ...[
-                  const Spacer(),
                   DefaultTextStyle(
                     style: labelStyle.copyWith(
                       color: selected ? textLuminance(selectedColor) : null,

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -413,12 +413,10 @@ class _SidebarItem extends StatelessWidget {
                     ),
                   ),
                 Expanded(
-                  child: DefaultTextStyle(
-                    style: labelStyle.copyWith(
-                      color: selected ? textLuminance(selectedColor) : null,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    child: item.label,
+                  child: _getTextStyleForLabel(
+                    labelStyle,
+                    selectedColor,
+                    context,
                   ),
                 ),
                 if (hasTrailing) ...[
@@ -435,6 +433,33 @@ class _SidebarItem extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+
+  DefaultTextStyle _getTextStyleForLabel(
+      TextStyle labelStyle, Color selectedColor, BuildContext context) {
+    if (item.section ?? true) {
+      final isDarkModeEnabled = MacosTheme.of(context).brightness.isDark;
+
+      return DefaultTextStyle(
+        style: labelStyle.copyWith(
+          fontWeight: FontWeight.bold,
+          fontSize: (labelStyle.fontSize ?? 14.0) * 0.85,
+          color: isDarkModeEnabled
+              ? MacosColors.white.withValues(alpha: 0.3)
+              : MacosColors.black.withValues(alpha: 0.3),
+          overflow: TextOverflow.ellipsis,
+        ),
+        child: item.label,
+      );
+    }
+
+    return DefaultTextStyle(
+      style: labelStyle.copyWith(
+        color: selected ? textLuminance(selectedColor) : null,
+        overflow: TextOverflow.ellipsis,
+      ),
+      child: item.label,
     );
   }
 }
@@ -544,6 +569,7 @@ class __DisclosureSidebarHeaderState extends State<_DisclosureSidebarHeaderItem>
               },
               child: _SidebarItem(
                 item: SidebarItem(
+                  section: true,
                   label: widget.item.label,
                   leading: (hasLeading)
                       ? Padding(
@@ -569,8 +595,8 @@ class __DisclosureSidebarHeaderState extends State<_DisclosureSidebarHeaderItem>
                             CupertinoIcons.chevron_right,
                             size: 14.0,
                             color: theme.brightness == Brightness.light
-                                ? MacosColors.black
-                                : MacosColors.white,
+                                ? MacosColors.black.withValues(alpha: 0.3)
+                                : MacosColors.white.withValues(alpha: 0.3),
                           ),
                         ),
                     ],

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -151,6 +151,15 @@ class SidebarItems extends StatelessWidget {
                       EdgeInsets.all(10.0 - theme.visualDensity.horizontal),
                   children: List.generate(items.length, (index) {
                     final item = items[index];
+                    if (item.section == true && item.disclosureItems != null) {
+                      return _DisclosureSidebarHeaderItem(
+                        item: item,
+                        selectedItem: _allItems[currentIndex],
+                        onChanged: (item) {
+                          onChanged(_allItems.indexOf(item));
+                        },
+                      );
+                    }
                     if (item.section == true) {
                       return _SidebarHeaderItem(item: item);
                     }
@@ -245,52 +254,52 @@ class _SidebarHeaderItem extends StatelessWidget {
     }
 
     return Semantics(
-      label: item.semanticLabel,
-      child: Container(
-      width: 134.0 + theme.visualDensity.horizontal,
-      height: itemSize.height + theme.visualDensity.vertical,
-      decoration: ShapeDecoration(
-        color: MacosColors.transparent,
-        shape: item.shape ?? _SidebarItemsConfiguration.of(context).shape,
-      ),
-      padding: EdgeInsets.symmetric(
-        vertical: 7 + theme.visualDensity.horizontal,
-        horizontal: spacing,
-      ),
-      child: Row(
-        children: [
-          if (hasLeading)
-            Padding(
-              padding: EdgeInsets.only(right: spacing),
-              child: MacosIconTheme.merge(
-                data: MacosIconThemeData(
-                  color: theme.primaryColor,
-                  size: itemSize.iconSize,
-                ),
-                child: item.leading!,
-              ),
-            ),
-          Expanded(
-            child: DefaultTextStyle(
-              style: labelStyle.copyWith(
-                color: null,
-                overflow: TextOverflow.ellipsis,
-              ),
-              child: item.label,
-            ),
+        label: item.semanticLabel,
+        child: Container(
+          width: 134.0 + theme.visualDensity.horizontal,
+          height: itemSize.height + theme.visualDensity.vertical,
+          decoration: ShapeDecoration(
+            color: MacosColors.transparent,
+            shape: item.shape ?? _SidebarItemsConfiguration.of(context).shape,
           ),
-          if (hasTrailing) ...[
-            const Spacer(),
-            DefaultTextStyle(
-              style: labelStyle.copyWith(
-                color: null,
+          padding: EdgeInsets.symmetric(
+            vertical: 7 + theme.visualDensity.horizontal,
+            horizontal: spacing,
+          ),
+          child: Row(
+            children: [
+              if (hasLeading)
+                Padding(
+                  padding: EdgeInsets.only(right: spacing),
+                  child: MacosIconTheme.merge(
+                    data: MacosIconThemeData(
+                      color: theme.primaryColor,
+                      size: itemSize.iconSize,
+                    ),
+                    child: item.leading!,
+                  ),
+                ),
+              Expanded(
+                child: DefaultTextStyle(
+                  style: labelStyle.copyWith(
+                    color: null,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  child: item.label,
+                ),
               ),
-              child: item.trailing!,
-            ),
-          ],
-        ],
-      ),
-    ));
+              if (hasTrailing) ...[
+                const Spacer(),
+                DefaultTextStyle(
+                  style: labelStyle.copyWith(
+                    color: null,
+                  ),
+                  child: item.trailing!,
+                ),
+              ],
+            ],
+          ),
+        ));
   }
 }
 
@@ -426,6 +435,210 @@ class _SidebarItem extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _DisclosureSidebarHeaderItem extends StatefulWidget {
+  // ignore: use_super_parameters
+  const _DisclosureSidebarHeaderItem({
+    Key? key,
+    required this.item,
+    this.selectedItem,
+    this.onChanged,
+  }) : super(key: key);
+
+  final SidebarItem item;
+
+  final SidebarItem? selectedItem;
+
+  /// A function to perform when the widget is clicked or tapped.
+  ///
+  /// Typically a [Navigator] call
+  final ValueChanged<SidebarItem>? onChanged;
+
+  @override
+  __DisclosureSidebarHeaderState createState() =>
+      __DisclosureSidebarHeaderState();
+}
+
+class __DisclosureSidebarHeaderState extends State<_DisclosureSidebarHeaderItem>
+    with SingleTickerProviderStateMixin {
+  static final Animatable<double> _easeInTween =
+      CurveTween(curve: Curves.easeIn);
+  static final Animatable<double> _halfTween =
+      Tween<double>(begin: 0, end: 0.25);
+
+  late AnimationController _controller;
+  late Animation<double> _iconTurns;
+  late Animation<double> _heightFactor;
+  late bool _isExpanded;
+  bool _isHovering = false;
+
+  bool get hasLeading => widget.item.leading != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(duration: _kExpand, vsync: this);
+    _heightFactor = _controller.drive(_easeInTween);
+    _iconTurns = _controller.drive(_halfTween.chain(_easeInTween));
+
+    _isExpanded = widget.item.expandDisclosureItems;
+    if (_isExpanded) {
+      _controller.forward();
+    }
+  }
+
+  void _handleTap() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+      if (_isExpanded) {
+        _controller.forward();
+      } else {
+        _controller.reverse().then<void>((void value) {
+          if (!mounted) return;
+          setState(() {
+            // Rebuild without widget.children.
+          });
+        });
+      }
+      PageStorage.of(context).writeState(context, _isExpanded);
+    });
+    // widget.onExpansionChanged?.call(_isExpanded);
+  }
+
+  Widget _buildChildren(BuildContext context, Widget? child) {
+    final theme = MacosTheme.of(context);
+
+    final itemSize = _SidebarItemsConfiguration.of(context).itemSize;
+    TextStyle? labelStyle;
+    switch (itemSize) {
+      case SidebarItemSize.small:
+        labelStyle = theme.typography.subheadline;
+        break;
+      case SidebarItemSize.medium:
+        labelStyle = theme.typography.body;
+        break;
+      case SidebarItemSize.large:
+        labelStyle = theme.typography.title3;
+        break;
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        SizedBox(
+            width: double.infinity,
+            child: MouseRegion(
+              onEnter: (e) => {
+                setState(() {
+                  _isHovering = true;
+                })
+              },
+              onExit: (e) => {
+                setState(() {
+                  _isHovering = false;
+                })
+              },
+              child: _SidebarItem(
+                item: SidebarItem(
+                  label: widget.item.label,
+                  leading: Row(
+                    children: [
+                      if (hasLeading)
+                        Padding(
+                          padding: const EdgeInsets.all(0),
+                          child: MacosIconTheme.merge(
+                            data: MacosIconThemeData(size: itemSize.iconSize),
+                            child: widget.item.leading!,
+                          ),
+                        ),
+                    ],
+                  ),
+                  unselectedColor: MacosColors.transparent,
+                  focusNode: widget.item.focusNode,
+                  semanticLabel: widget.item.semanticLabel,
+                  shape: widget.item.shape,
+                  trailing: Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      if (widget.item.trailing != null) widget.item.trailing!,
+                      if (_isHovering)
+                        RotationTransition(
+                          turns: _iconTurns,
+                          child: Icon(
+                            CupertinoIcons.chevron_right,
+                            size: 14.0,
+                            color: theme.brightness == Brightness.light
+                                ? MacosColors.black
+                                : MacosColors.white,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+                onClick: _handleTap,
+                selected: false,
+              ),
+            )),
+        ClipRect(
+          child: DefaultTextStyle(
+            style: labelStyle,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              heightFactor: _heightFactor.value,
+              child: child,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasMacosTheme(context));
+    final theme = MacosTheme.of(context);
+
+    final bool closed = !_isExpanded && _controller.isDismissed;
+
+    final Widget result = Offstage(
+      offstage: closed,
+      child: TickerMode(
+        enabled: !closed,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: widget.item.disclosureItems!.map((item) {
+            return Padding(
+              padding: EdgeInsets.only(
+                left: 24.0 + theme.visualDensity.horizontal,
+              ),
+              child: SizedBox(
+                width: double.infinity,
+                child: _SidebarItem(
+                  item: item,
+                  onClick: () => widget.onChanged?.call(item),
+                  selected: widget.selectedItem == item,
+                ),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+
+    return AnimatedBuilder(
+      animation: _controller.view,
+      builder: _buildChildren,
+      child: closed ? null : result,
     );
   }
 }

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -280,7 +280,7 @@ class _SidebarHeaderItem extends StatelessWidget {
                   ),
                 ),
               Expanded(
-                child: _getTextStyleForLabel(labelStyle, context),
+                child: _buildLabelWithDefaultTextStyle(labelStyle, context),
               ),
               if (hasTrailing) ...[
                 const Spacer(),
@@ -296,7 +296,7 @@ class _SidebarHeaderItem extends StatelessWidget {
         ));
   }
 
-  DefaultTextStyle _getTextStyleForLabel(
+  DefaultTextStyle _buildLabelWithDefaultTextStyle(
       TextStyle labelStyle, BuildContext context) {
     final isDarkModeEnabled = MacosTheme.of(context).brightness.isDark;
 
@@ -424,7 +424,7 @@ class _SidebarItem extends StatelessWidget {
                     ),
                   ),
                 Expanded(
-                  child: _getTextStyleForLabel(
+                  child: _buildLabelWithDefaultTextStyle(
                     labelStyle,
                     selectedColor,
                     context,
@@ -447,7 +447,7 @@ class _SidebarItem extends StatelessWidget {
     );
   }
 
-  DefaultTextStyle _getTextStyleForLabel(
+  DefaultTextStyle _buildLabelWithDefaultTextStyle(
       TextStyle labelStyle, Color selectedColor, BuildContext context) {
     if (item.section ?? true) {
       final isDarkModeEnabled = MacosTheme.of(context).brightness.isDark;

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -280,13 +280,7 @@ class _SidebarHeaderItem extends StatelessWidget {
                   ),
                 ),
               Expanded(
-                child: DefaultTextStyle(
-                  style: labelStyle.copyWith(
-                    color: null,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  child: item.label,
-                ),
+                child: _getTextStyleForLabel(labelStyle, context),
               ),
               if (hasTrailing) ...[
                 const Spacer(),
@@ -300,6 +294,23 @@ class _SidebarHeaderItem extends StatelessWidget {
             ],
           ),
         ));
+  }
+
+  DefaultTextStyle _getTextStyleForLabel(
+      TextStyle labelStyle, BuildContext context) {
+    final isDarkModeEnabled = MacosTheme.of(context).brightness.isDark;
+
+    return DefaultTextStyle(
+      style: labelStyle.copyWith(
+        fontWeight: FontWeight.bold,
+        fontSize: (labelStyle.fontSize ?? 14.0) * 0.85,
+        color: isDarkModeEnabled
+            ? MacosColors.white.withValues(alpha: 0.3)
+            : MacosColors.black.withValues(alpha: 0.3),
+        overflow: TextOverflow.ellipsis,
+      ),
+      child: item.label,
+    );
   }
 }
 

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -545,18 +545,15 @@ class __DisclosureSidebarHeaderState extends State<_DisclosureSidebarHeaderItem>
               child: _SidebarItem(
                 item: SidebarItem(
                   label: widget.item.label,
-                  leading: Row(
-                    children: [
-                      if (hasLeading)
-                        Padding(
+                  leading: (hasLeading)
+                      ? Padding(
                           padding: const EdgeInsets.all(0),
                           child: MacosIconTheme.merge(
                             data: MacosIconThemeData(size: itemSize.iconSize),
                             child: widget.item.leading!,
                           ),
-                        ),
-                    ],
-                  ),
+                        )
+                      : null,
                   unselectedColor: MacosColors.transparent,
                   focusNode: widget.item.focusNode,
                   semanticLabel: widget.item.semanticLabel,

--- a/lib/src/layout/sidebar/sidebar_items.dart
+++ b/lib/src/layout/sidebar/sidebar_items.dart
@@ -118,7 +118,7 @@ class SidebarItems extends StatelessWidget {
     for (var element in items) {
       if (element.disclosureItems != null) {
         result.addAll(element.disclosureItems!);
-      } else {
+      } else if (element.section == false) {
         result.add(element);
       }
     }
@@ -163,6 +163,9 @@ class SidebarItems extends StatelessWidget {
                         ),
                       );
                     }
+                    if (item.section == true) {
+                      return _SidebarHeaderItem(item: item);
+                    }
                     return MouseRegion(
                       cursor: cursor!,
                       child: _SidebarItem(
@@ -206,6 +209,88 @@ class _SidebarItemsConfiguration extends InheritedWidget {
   @override
   bool updateShouldNotify(_SidebarItemsConfiguration oldWidget) {
     return true;
+  }
+}
+
+class _SidebarHeaderItem extends StatelessWidget {
+  // ignore: use_super_parameters
+  const _SidebarHeaderItem({
+    Key? key,
+    required this.item,
+  }) : super(key: key);
+
+  final SidebarItem item;
+
+  bool get hasLeading => item.leading != null;
+  bool get hasTrailing => item.trailing != null;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasMacosTheme(context));
+    final theme = MacosTheme.of(context);
+
+    final double spacing = 10.0 + theme.visualDensity.horizontal;
+    final itemSize = _SidebarItemsConfiguration.of(context).itemSize;
+    TextStyle? labelStyle;
+    switch (itemSize) {
+      case SidebarItemSize.small:
+        labelStyle = theme.typography.subheadline;
+        break;
+      case SidebarItemSize.medium:
+        labelStyle = theme.typography.body;
+        break;
+      case SidebarItemSize.large:
+        labelStyle = theme.typography.title3;
+        break;
+    }
+
+    return Semantics(
+      label: item.semanticLabel,
+      child: Container(
+      width: 134.0 + theme.visualDensity.horizontal,
+      height: itemSize.height + theme.visualDensity.vertical,
+      decoration: ShapeDecoration(
+        color: MacosColors.transparent,
+        shape: item.shape ?? _SidebarItemsConfiguration.of(context).shape,
+      ),
+      padding: EdgeInsets.symmetric(
+        vertical: 7 + theme.visualDensity.horizontal,
+        horizontal: spacing,
+      ),
+      child: Row(
+        children: [
+          if (hasLeading)
+            Padding(
+              padding: EdgeInsets.only(right: spacing),
+              child: MacosIconTheme.merge(
+                data: MacosIconThemeData(
+                  color: theme.primaryColor,
+                  size: itemSize.iconSize,
+                ),
+                child: item.leading!,
+              ),
+            ),
+          Expanded(
+            child: DefaultTextStyle(
+              style: labelStyle.copyWith(
+                color: null,
+                overflow: TextOverflow.ellipsis,
+              ),
+              child: item.label,
+            ),
+          ),
+          if (hasTrailing) ...[
+            const Spacer(),
+            DefaultTextStyle(
+              style: labelStyle.copyWith(
+                color: null,
+              ),
+              child: item.trailing!,
+            ),
+          ],
+        ],
+      ),
+    ));
   }
 }
 

--- a/lib/src/sheets/macos_sheet.dart
+++ b/lib/src/sheets/macos_sheet.dart
@@ -114,7 +114,10 @@ Future<T?> showMacosSheet<T>({
   barrierColor ??= MacosDynamicColor.resolve(
     MacosColors.controlBackgroundColor,
     context,
-  ).withValues(alpha: 0.6);
+  );
+
+  barrierColor = Color.fromRGBO((barrierColor.r * 255).floor(),
+      (barrierColor.g * 255).floor(), (barrierColor.b * 255).floor(), 0.6);
 
   return Navigator.of(context, rootNavigator: useRootNavigator).push<T>(
     _MacosSheetRoute<T>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.1.4
+version: 2.1.5
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.1.5
+version: 2.1.6
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
Add an additional `section` parameter to SidebarItem to convert it into an unclickable widget so it can be used as a section header. It may be better to design a dedicated `Section` widget for this task but this workaround works well for me now.
<img width="194" alt="Capture d’écran, le 2025-01-07 à 3 32 48 p m" src="https://github.com/user-attachments/assets/905f1036-06a2-43c3-a859-b95083ccf3fa" />

## Pre-launch Checklist


- [x] I have incremented the package version as appropriate and updated `CHANGELOG.md` with my changes <!-- THIS IS REQUIRED -->
- [x] I have added/updated relevant documentation <!-- If relevant -->
- [x] I have run "optimize/organize imports" on all changed files
- [x] I have addressed all analyzer warnings as best I could