### PR TITLE
Fix MacosPulldownButton menu panel appearance to better match MacOS 15.x

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.8"
+    version: "2.1.9"
   macos_window_utils:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.9"
+    version: "2.1.8"
   macos_window_utils:
     dependency: transitive
     description:

--- a/lib/src/buttons/popup_button.dart
+++ b/lib/src/buttons/popup_button.dart
@@ -281,7 +281,21 @@ class _MacosPopupMenuState<T> extends State<_MacosPopupMenu<T>> {
                 return true;
               },
               child: MacosOverlayFilter(
-                color: popupColor?.withValues(alpha: 0.25),
+
+
+
+                // BP CHANGE
+                // REPLACE
+                // color: popupColor?.withValues(alpha: 0.25),
+                // WITH
+                color: popupColor?.withValues(alpha: 0.85),
+                // REASON
+                // REASON: lightening default dark color at MacosPopupButtonThemeData.popupColor init 
+                // makes lightening here via super-low alpha unnecessary, thereby eliminating
+                // the non-macOS-15.x severe transparency effect.
+
+
+
                 borderRadius: _kBorderRadius,
                 child: Column(
                   mainAxisSize: MainAxisSize.min,

--- a/lib/src/buttons/pulldown_button.dart
+++ b/lib/src/buttons/pulldown_button.dart
@@ -201,8 +201,15 @@ class _MacosPulldownMenuState extends State<_MacosPulldownMenu> {
         child: IntrinsicWidth(
           child: MacosOverlayFilter(
             color: MacosPulldownButtonTheme.of(context)
-                .pulldownColor
-                ?.withValues(alpha: 0.25),
+              .pulldownColor
+              // BP CHANGE
+              // REPLACE
+              // ?.withValues(alpha: 0.25),            
+              // WITH
+              ?.withValues(alpha: 0.85),
+              // REASON: lightening default dark color at MacosThemeData.pulldownColor init 
+              // makes lightening here via super-low alpha unnecessary, thereby eliminating
+              // the non-macOS-15.x severe transparency effect.
             borderRadius: _kBorderRadius,
             child: Padding(
               padding: const EdgeInsets.all(6.0),

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -1258,7 +1258,8 @@ class _MacosTextFieldState extends State<MacosTextField>
         widget.keyboardAppearance ?? MacosTheme.brightnessOf(context);
     Color? cursorColor;
     cursorColor = MacosDynamicColor.maybeResolve(widget.cursorColor, context);
-    cursorColor ??=
+    cursorColor ??= textStyle.color; // next best is "match text"
+    cursorColor ??=  // last resort - fall back to theme forground color
         themeData.brightness.isDark ? MacosColors.white : MacosColors.black;
     final Color disabledColor =
         MacosDynamicColor.resolve(_kDisabledBackground, context);

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -1258,8 +1258,7 @@ class _MacosTextFieldState extends State<MacosTextField>
         widget.keyboardAppearance ?? MacosTheme.brightnessOf(context);
     Color? cursorColor;
     cursorColor = MacosDynamicColor.maybeResolve(widget.cursorColor, context);
-    cursorColor ??= textStyle.color; // next best is "match text"
-    cursorColor ??=  // last resort - fall back to theme forground color
+    cursorColor ??=
         themeData.brightness.isDark ? MacosColors.white : MacosColors.black;
     final Color disabledColor =
         MacosDynamicColor.resolve(_kDisabledBackground, context);

--- a/lib/src/layout/toolbar/toolbar_overflow_menu.dart
+++ b/lib/src/layout/toolbar/toolbar_overflow_menu.dart
@@ -27,7 +27,14 @@ class ToolbarOverflowMenu extends StatelessWidget {
         child: MacosOverlayFilter(
           color: MacosPulldownButtonTheme.of(context)
               .pulldownColor
-              ?.withValues(alpha: 0.25),
+              // BP CHANGE THIS
+              // REPLACE
+              // ?.withValues(alpha: 0.25),            
+              // WITH
+              ?.withValues(alpha: 0.85),
+              // REASON: lightening default dark color at MacosThemeData.pulldownColor init 
+              // makes lightening here via super-low alpha unnecessary, thereby eliminating
+              // the non-macOS-15.x severe transparency effect.
           borderRadius: _kBorderRadius,
           child: Padding(
             padding: const EdgeInsets.all(6.0),

--- a/lib/src/theme/macos_colors.dart
+++ b/lib/src/theme/macos_colors.dart
@@ -376,6 +376,16 @@ class MacosColors {
     darkColor: Color.fromRGBO(255, 255, 255, 0.1),
   );
 
+  // BP CHANGE
+  // ADD
+  // Text color for pulldown menus (e.g. ToolBarPullDownButton)
+  // (these colors derived from light/dark toolbar pulldown menus in Apple Pages app)
+  static const pulldownMenuTextColor = CupertinoDynamicColor.withBrightness(
+    color: Color.fromRGBO(37, 37, 37, 1.0),
+    darkColor: Color.fromRGBO(229, 229, 229, 1.0),
+  );
+  // END
+
   /// The accent color selected by the user in system preferences.
   ///
   /// No dark variant.

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -304,8 +304,17 @@ class MacosThemeData extends Equatable with Diagnosticable {
           ? const Color.fromRGBO(255, 255, 255, 0.247)
           : const Color.fromRGBO(255, 255, 255, 1),
       pulldownColor: isDark
-          ? const Color.fromRGBO(30, 30, 30, 1)
-          : const Color.fromRGBO(242, 242, 247, 1),
+          // BP CHANGE
+          // REPLACE
+          // ? const Color.fromRGBO(30, 30, 30, 1)
+          // : const Color.fromRGBO(242, 242, 247, 1),
+          // WITH
+          ? const Color.fromRGBO(80, 80, 80, 1)
+          : const Color.fromRGBO(235, 235, 235, 1),
+          // REASON: dark color is much too dark, and requires ligtening with a very-low
+          //   alpha value that gives the result a severely non-macOS-15.x transparency 
+          //   effect for pulldown menu panes.
+          //   Change requires darkening light color to match MacOS-15.x appearance.
       iconColor: isDark
           ? const Color.fromRGBO(255, 255, 255, 0.7)
           : const Color.fromRGBO(0, 0, 0, 0.7),

--- a/lib/src/theme/macos_theme.dart
+++ b/lib/src/theme/macos_theme.dart
@@ -290,8 +290,21 @@ class MacosThemeData extends Equatable with Diagnosticable {
           ? const Color.fromRGBO(255, 255, 255, 0.247)
           : const Color.fromRGBO(255, 255, 255, 1),
       popupColor: isDark
-          ? const Color.fromRGBO(30, 30, 30, 1)
-          : const Color.fromRGBO(242, 242, 247, 1),
+
+
+          // BP CHANGE
+          // REPLACE
+          // ? const Color.fromRGBO(30, 30, 30, 1)
+          // : const Color.fromRGBO(242, 242, 247, 1),
+          // WITH
+          ? const Color.fromRGBO(80, 80, 80, 1)
+          : const Color.fromRGBO(235, 235, 235, 1),
+          // REASON: dark color is much too dark, and requires ligtening with a very-low
+          //   alpha value that gives the result a severely non-macOS-15.x transparency 
+          //   effect for pulldown menu panes.
+          //   Change requires darkening light color to match MacOS-15.x appearance.
+
+
     );
 
     pulldownButtonTheme ??= MacosPulldownButtonThemeData(

--- a/lib/src/theme/overlay_filter.dart
+++ b/lib/src/theme/overlay_filter.dart
@@ -51,7 +51,12 @@ class MacosOverlayFilter extends StatelessWidget {
                     CupertinoColors.systemGrey.color,
                     CupertinoColors.black,
                   )
-                  .withValues(alpha: 0.25),
+                  // BP CHANGE
+                  // REPLACE
+                  // .withValues(alpha: 0.25),
+                  // WITH
+                  .withValues(alpha: 0.15),
+                  // REASON: shadow density is excessive. Lighter is closer to mac OS.
               offset: const Offset(0, 4),
               spreadRadius: 4.0,
               blurRadius: 8.0,
@@ -67,13 +72,24 @@ class MacosOverlayFilter extends StatelessWidget {
         ),
         child: ClipRRect(
           borderRadius: borderRadius,
-          child: BackdropFilter(
-            filter: ImageFilter.blur(
-              sigmaX: 20.0,
-              sigmaY: 20.0,
-            ),
+
+          // BP CHANGE
+          // REPLACE
+          // child: BackdropFilter(
+          //   filter: ImageFilter.blur(
+          //     sigmaX: 20.0,
+          //     sigmaY: 20.0,
+          //   ),
+          //   child: child,
+          // ),
+          // WITH
             child: child,
-          ),
+          // REASON: this blur is insane, and nothing like actual mac appearance in 15.x 
+          // Is this a leftover from an earlier macos "glassy" appearance standard?
+          // The blur severely severely alters the pulldown menu panel appearance from 
+          // macOS 15.x appearance in Apple's apps (pages, etc).
+          // Does not belong if standard is "look like 15.x"
+
         ),
       ),
     );


### PR DESCRIPTION
Default appearance of _MacosPulldownMenu menu panel does not match at all the appearance of Toolbar pulldown menus in applications by Apple in MacOS 15.x. There is too much transparency, there's no defined MacosColor for actual text colors used by Apple, there's non-standard blur effects applied.

This set of changes alters the behavior of macos_ui to more closely resemble the standard Apple app appearance. 

There's some discussion in issue #557  that I started but then abandoned. 

I'm not updating the changelog, as I don't actually expect this PR to be accepted. Consider it reference code for a possible approach to altering this behavior, if one of the project contributors decides a change like this would be appropriate at some point.

Thanks for all your hard work on this project. Use this if you like. Cheers!
