### PR TITLE
MacosTextField : Default cursor color to text color when not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.1.10]
+### 🔄 Updated 🔄
+* Make text field cursor color follow the user’s accent color if not explicitly set (thanks, [@driftwoodstudio](https://github.com/driftwoodstudio)).
+* Expose the `AccentColorListener` class to macos_ui users.
+
 ## [2.1.9]
 ### 🛠️ Fixed 🛠️
 * Fix incorrect highlighting and focusing behavior of `_MacosPopupMenuItemButton`.

--- a/lib/macos_ui.dart
+++ b/lib/macos_ui.dart
@@ -90,3 +90,4 @@ export 'src/theme/tooltip_theme.dart';
 export 'src/theme/typography.dart';
 export 'src/enums/accent_color.dart';
 export 'src/utils/window_main_state_listener.dart';
+export 'src/utils/accent_color_listener.dart';

--- a/lib/src/buttons/checkbox.dart
+++ b/lib/src/buttons/checkbox.dart
@@ -365,9 +365,6 @@ class _BoxDecorationBuilder {
             MacosColor.fromRGBO(148, 148, 148, 1.0 * isEnabledFactor),
             MacosColor.fromRGBO(148, 148, 148, 1.0 * isEnabledFactor),
           ];
-
-        default:
-          throw UnimplementedError();
       }
     } else {
       switch (accentColor) {
@@ -418,9 +415,6 @@ class _BoxDecorationBuilder {
             MacosColor.fromRGBO(86, 86, 86, 1.0 * isEnabledFactor),
             MacosColor.fromRGBO(55, 55, 55, 1.0 * isEnabledFactor),
           ];
-
-        default:
-          throw UnimplementedError();
       }
     }
   }

--- a/lib/src/buttons/push_button.dart
+++ b/lib/src/buttons/push_button.dart
@@ -458,9 +458,6 @@ class _BoxDecorationBuilder {
             MacosColor.fromRGBO(64, 64, 64, 1.0 * isEnabledFactor),
             MacosColor.fromRGBO(57, 57, 57, 1.0 * isEnabledFactor),
           ];
-
-        default:
-          throw UnimplementedError();
       }
     } else {
       switch (accentColor) {
@@ -511,9 +508,6 @@ class _BoxDecorationBuilder {
             MacosColor.fromRGBO(86, 86, 86, 1.0 * isEnabledFactor),
             MacosColor.fromRGBO(55, 55, 55, 1.0 * isEnabledFactor),
           ];
-
-        default:
-          throw UnimplementedError();
       }
     }
   }
@@ -649,9 +643,6 @@ class _BoxDecorationBuilder {
               blurStyle: isEnabled ? BlurStyle.normal : BlurStyle.outer,
             ),
           ];
-
-        default:
-          throw UnimplementedError();
       }
     }
   }

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -1258,7 +1258,8 @@ class _MacosTextFieldState extends State<MacosTextField>
         widget.keyboardAppearance ?? MacosTheme.brightnessOf(context);
     Color? cursorColor;
     cursorColor = MacosDynamicColor.maybeResolve(widget.cursorColor, context);
-    cursorColor ??=
+    cursorColor ??= textStyle.color; // next best is "match text"
+    cursorColor ??=  // last resort - fall back to theme forground color
         themeData.brightness.isDark ? MacosColors.white : MacosColors.black;
     final Color disabledColor =
         MacosDynamicColor.resolve(_kDisabledBackground, context);

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -1,6 +1,5 @@
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
-import 'package:appkit_ui_element_colors/appkit_ui_element_colors.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';

--- a/lib/src/fields/text_field.dart
+++ b/lib/src/fields/text_field.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 
+import 'package:appkit_ui_element_colors/appkit_ui_element_colors.dart';
 import 'package:flutter/foundation.dart' show defaultTargetPlatform;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -1189,258 +1190,320 @@ class _MacosTextFieldState extends State<MacosTextField>
         : TextAlignVertical.top;
   }
 
+  Color? _resolveAccentColor(BuildContext context, AccentColor? accentColor) {
+    if (accentColor == null) {
+      return null;
+    }
+
+    final isDarkModeActive = MacosTheme.of(context).brightness.isDark;
+
+    if (isDarkModeActive) {
+      switch (accentColor) {
+        case AccentColor.blue:
+          return const Color.fromRGBO(0, 122, 255, 1.0);
+        case AccentColor.purple:
+          return const Color.fromRGBO(165, 80, 167, 1.0);
+        case AccentColor.pink:
+          return const Color.fromRGBO(247, 79, 158, 1.0);
+        case AccentColor.red:
+          return const Color.fromRGBO(255, 82, 87, 1.0);
+        case AccentColor.orange:
+          return const Color.fromRGBO(247, 130, 27, 1.0);
+        case AccentColor.yellow:
+          return const Color.fromRGBO(255, 198, 0, 1.0);
+        case AccentColor.green:
+          return const Color.fromRGBO(98, 186, 70, 1.0);
+        case AccentColor.graphite:
+          return const Color.fromRGBO(137, 137, 137, 1.0);
+      }
+    }
+
+    switch (accentColor) {
+      case AccentColor.blue:
+        return const Color.fromRGBO(0, 122, 255, 1.0);
+      case AccentColor.purple:
+        return const Color.fromRGBO(150, 51, 150, 1.0);
+      case AccentColor.pink:
+        return const Color.fromRGBO(247, 79, 158, 1.0);
+      case AccentColor.red:
+        return const Color.fromRGBO(224, 56, 62, 1.0);
+      case AccentColor.orange:
+        return const Color.fromRGBO(247, 130, 27, 1.0);
+      case AccentColor.yellow:
+        return const Color.fromRGBO(255, 199, 38, 1.0);
+      case AccentColor.green:
+        return const Color.fromRGBO(98, 186, 70, 1.0);
+      case AccentColor.graphite:
+        return const Color.fromRGBO(152, 152, 152, 1.0);
+    }
+  }
+
   @override
   // ignore: code-metrics
   Widget build(BuildContext context) {
     super.build(context); // See AutomaticKeepAliveClientMixin.
     assert(debugCheckHasDirectionality(context));
     assert(debugCheckHasMacosTheme(context));
-    final TextEditingController controller = _effectiveController;
+    return StreamBuilder(
+        stream: AccentColorListener.instance.onChanged,
+        builder: (context, _) {
+          final TextEditingController controller = _effectiveController;
 
-    TextSelectionControls? textSelectionControls = widget.selectionControls;
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        textSelectionControls ??= cupertinoTextSelectionControls;
-        break;
+          TextSelectionControls? textSelectionControls =
+              widget.selectionControls;
+          switch (defaultTargetPlatform) {
+            case TargetPlatform.iOS:
+            case TargetPlatform.android:
+            case TargetPlatform.fuchsia:
+              textSelectionControls ??= cupertinoTextSelectionControls;
+              break;
 
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-      case TargetPlatform.macOS:
-        textSelectionControls ??= cupertinoDesktopTextSelectionControls;
-        break;
-    }
-
-    final bool enabled = widget.enabled ?? true;
-    final Offset cursorOffset = Offset(
-      _iOSHorizontalCursorOffsetPixels /
-          MediaQuery.of(context).devicePixelRatio,
-      0,
-    );
-    final List<TextInputFormatter> formatters = <TextInputFormatter>[
-      ...?widget.inputFormatters,
-      if (widget.maxLength != null)
-        LengthLimitingTextInputFormatter(
-          widget.maxLength,
-          maxLengthEnforcement: _effectiveMaxLengthEnforcement,
-        ),
-    ];
-    final MacosThemeData themeData = MacosTheme.of(context);
-
-    final TextStyle? resolvedStyle = widget.style?.copyWith(
-      color: MacosDynamicColor.maybeResolve(widget.style?.color, context),
-      backgroundColor: MacosDynamicColor.maybeResolve(
-        widget.style?.backgroundColor,
-        context,
-      ),
-    );
-
-    final textStyle = themeData.typography.body.merge(resolvedStyle);
-
-    final resolvedPlaceholderStyle = widget.placeholderStyle?.copyWith(
-      color: MacosDynamicColor.maybeResolve(
-        widget.placeholderStyle?.color,
-        context,
-      ),
-      backgroundColor: MacosDynamicColor.maybeResolve(
-        widget.placeholderStyle?.backgroundColor,
-        context,
-      ),
-    );
-
-    final placeholderStyle = textStyle.merge(enabled
-        ? resolvedPlaceholderStyle
-        : resolvedPlaceholderStyle!.copyWith(
-            color: resolvedPlaceholderStyle.color!.withValues(alpha: 0.2)));
-
-    final Brightness keyboardAppearance =
-        widget.keyboardAppearance ?? MacosTheme.brightnessOf(context);
-    Color? cursorColor;
-    cursorColor = MacosDynamicColor.maybeResolve(widget.cursorColor, context);
-    cursorColor ??= textStyle.color; // next best is "match text"
-    cursorColor ??=  // last resort - fall back to theme forground color
-        themeData.brightness.isDark ? MacosColors.white : MacosColors.black;
-    final Color disabledColor =
-        MacosDynamicColor.resolve(_kDisabledBackground, context);
-
-    Color? decorationColor =
-        MacosDynamicColor.maybeResolve(widget.decoration?.color, context);
-    if (decorationColor.runtimeType == ResolvedMacosDynamicColor) {
-      if ((decorationColor as ResolvedMacosDynamicColor).color ==
-              const Color(0xffffffff) ||
-          (decorationColor).darkColor == const Color(0xff000000)) {
-        decorationColor = themeData.brightness.isDark
-            ? const Color.fromRGBO(30, 30, 30, 1)
-            : MacosColors.white;
-      }
-    }
-
-    final BoxBorder? border = widget.decoration?.border;
-    Border? resolvedBorder = border as Border?;
-    if (border is Border) {
-      BorderSide resolveBorderSide(BorderSide side) {
-        return side == BorderSide.none
-            ? side
-            : side.copyWith(
-                color: MacosDynamicColor.resolve(side.color, context),
-              );
-      }
-
-      resolvedBorder = border.runtimeType != Border
-          ? border
-          : Border(
-              top: resolveBorderSide(border.top),
-              left: resolveBorderSide(border.left),
-              bottom: resolveBorderSide(border.bottom),
-              right: resolveBorderSide(border.right),
-            );
-    }
-
-    final BoxDecoration? effectiveDecoration = widget.decoration?.copyWith(
-      border: resolvedBorder,
-      color: enabled ? decorationColor : disabledColor,
-    );
-
-    final BoxDecoration? focusedDecoration = widget.focusedDecoration?.copyWith(
-      border: Border.all(
-        width: 3.0,
-        color: themeData.brightness.isDark
-            ? const Color.fromRGBO(26, 169, 255, 0.3)
-            : const Color.fromRGBO(0, 103, 244, 0.25),
-      ),
-    );
-
-    final focusedPlaceholderDecoration = focusedDecoration?.copyWith(
-      border: () {
-        if (focusedDecoration.border is Border) {
-          BorderSide borderSide(BorderSide fromSide) {
-            return BorderSide(
-              color: fromSide.color.withValues(alpha: 0.0),
-              style: fromSide.style,
-              width: fromSide.width,
-            );
+            case TargetPlatform.linux:
+            case TargetPlatform.windows:
+            case TargetPlatform.macOS:
+              textSelectionControls ??= cupertinoDesktopTextSelectionControls;
+              break;
           }
 
-          return Border(
-            bottom: borderSide((focusedDecoration.border as Border).bottom),
-            top: borderSide((focusedDecoration.border as Border).top),
-            left: borderSide((focusedDecoration.border as Border).left),
-            right: borderSide((focusedDecoration.border as Border).right),
+          final bool enabled = widget.enabled ?? true;
+          final Offset cursorOffset = Offset(
+            _iOSHorizontalCursorOffsetPixels /
+                MediaQuery.of(context).devicePixelRatio,
+            0,
           );
-        }
-        return focusedDecoration.border;
-      }(),
-      color: focusedDecoration.color ?? const Color(0x00000000),
-    );
+          final List<TextInputFormatter> formatters = <TextInputFormatter>[
+            ...?widget.inputFormatters,
+            if (widget.maxLength != null)
+              LengthLimitingTextInputFormatter(
+                widget.maxLength,
+                maxLengthEnforcement: _effectiveMaxLengthEnforcement,
+              ),
+          ];
+          final MacosThemeData themeData = MacosTheme.of(context);
 
-    final Color selectionColor =
-        MacosTheme.of(context).primaryColor.withValues(alpha: 0.2);
-
-    final Widget paddedEditable = Padding(
-      padding: widget.padding,
-      child: RepaintBoundary(
-        child: UnmanagedRestorationScope(
-          bucket: bucket,
-          child: EditableText(
-            key: editableTextKey,
-            controller: controller,
-            readOnly: widget.readOnly,
-            showCursor: widget.showCursor,
-            showSelectionHandles: _showSelectionHandles,
-            focusNode: _effectiveFocusNode,
-            keyboardType: widget.keyboardType,
-            textInputAction: widget.textInputAction,
-            textCapitalization: widget.textCapitalization,
-            style: textStyle,
-            strutStyle: widget.strutStyle,
-            textAlign: widget.textAlign,
-            autofocus: widget.autofocus,
-            obscuringCharacter: widget.obscuringCharacter,
-            obscureText: widget.obscureText,
-            autocorrect: widget.autocorrect,
-            smartDashesType: widget.smartDashesType,
-            smartQuotesType: widget.smartQuotesType,
-            enableSuggestions: widget.enableSuggestions,
-            maxLines: widget.maxLines,
-            minLines: widget.minLines,
-            expands: widget.expands,
-            selectionColor: selectionColor,
-            selectionControls:
-                widget.selectionEnabled ? textSelectionControls : null,
-            onChanged: widget.onChanged,
-            onSelectionChanged: _handleSelectionChanged,
-            onEditingComplete: widget.onEditingComplete,
-            onSubmitted: widget.onSubmitted,
-            inputFormatters: formatters,
-            rendererIgnoresPointer: true,
-            cursorWidth: widget.cursorWidth,
-            cursorHeight: widget.cursorHeight,
-            cursorRadius: widget.cursorRadius,
-            cursorColor: cursorColor,
-            cursorOpacityAnimates: true,
-            cursorOffset: cursorOffset,
-            paintCursorAboveText: true,
-            autocorrectionTextRectColor: selectionColor,
-            backgroundCursorColor: MacosDynamicColor.resolve(
-              CupertinoColors.inactiveGray,
+          final TextStyle? resolvedStyle = widget.style?.copyWith(
+            color: MacosDynamicColor.maybeResolve(widget.style?.color, context),
+            backgroundColor: MacosDynamicColor.maybeResolve(
+              widget.style?.backgroundColor,
               context,
             ),
-            selectionHeightStyle: widget.selectionHeightStyle,
-            selectionWidthStyle: widget.selectionWidthStyle,
-            scrollPadding: widget.scrollPadding,
-            keyboardAppearance: keyboardAppearance,
-            dragStartBehavior: widget.dragStartBehavior,
-            scrollController: widget.scrollController,
-            scrollPhysics: widget.scrollPhysics,
-            enableInteractiveSelection: widget.enableInteractiveSelection,
-            autofillHints: widget.autofillHints,
-            restorationId: 'editable',
-            mouseCursor: SystemMouseCursors.text,
-            contextMenuBuilder: widget.contextMenuBuilder,
-          ),
-        ),
-      ),
-    );
+          );
 
-    return Semantics(
-      enabled: enabled,
-      onTap: !enabled || widget.readOnly
-          ? null
-          : () {
-              if (!controller.selection.isValid) {
-                controller.selection =
-                    TextSelection.collapsed(offset: controller.text.length);
+          final textStyle = themeData.typography.body.merge(resolvedStyle);
+
+          final resolvedPlaceholderStyle = widget.placeholderStyle?.copyWith(
+            color: MacosDynamicColor.maybeResolve(
+              widget.placeholderStyle?.color,
+              context,
+            ),
+            backgroundColor: MacosDynamicColor.maybeResolve(
+              widget.placeholderStyle?.backgroundColor,
+              context,
+            ),
+          );
+
+          final placeholderStyle = textStyle.merge(enabled
+              ? resolvedPlaceholderStyle
+              : resolvedPlaceholderStyle!.copyWith(
+                  color:
+                      resolvedPlaceholderStyle.color!.withValues(alpha: 0.2)));
+
+          final Brightness keyboardAppearance =
+              widget.keyboardAppearance ?? MacosTheme.brightnessOf(context);
+          Color? cursorColor;
+          cursorColor =
+              MacosDynamicColor.maybeResolve(widget.cursorColor, context);
+          cursorColor ??= _resolveAccentColor(
+              context, AccentColorListener.instance.currentAccentColor);
+          cursorColor ??= textStyle.color; // next best is "match text"
+          cursorColor ??= // last resort - fall back to theme forground color
+              themeData.brightness.isDark
+                  ? MacosColors.white
+                  : MacosColors.black;
+          final Color disabledColor =
+              MacosDynamicColor.resolve(_kDisabledBackground, context);
+
+          Color? decorationColor =
+              MacosDynamicColor.maybeResolve(widget.decoration?.color, context);
+          if (decorationColor.runtimeType == ResolvedMacosDynamicColor) {
+            if ((decorationColor as ResolvedMacosDynamicColor).color ==
+                    const Color(0xffffffff) ||
+                (decorationColor).darkColor == const Color(0xff000000)) {
+              decorationColor = themeData.brightness.isDark
+                  ? const Color.fromRGBO(30, 30, 30, 1)
+                  : MacosColors.white;
+            }
+          }
+
+          final BoxBorder? border = widget.decoration?.border;
+          Border? resolvedBorder = border as Border?;
+          if (border is Border) {
+            BorderSide resolveBorderSide(BorderSide side) {
+              return side == BorderSide.none
+                  ? side
+                  : side.copyWith(
+                      color: MacosDynamicColor.resolve(side.color, context),
+                    );
+            }
+
+            resolvedBorder = border.runtimeType != Border
+                ? border
+                : Border(
+                    top: resolveBorderSide(border.top),
+                    left: resolveBorderSide(border.left),
+                    bottom: resolveBorderSide(border.bottom),
+                    right: resolveBorderSide(border.right),
+                  );
+          }
+
+          final BoxDecoration? effectiveDecoration =
+              widget.decoration?.copyWith(
+            border: resolvedBorder,
+            color: enabled ? decorationColor : disabledColor,
+          );
+
+          final BoxDecoration? focusedDecoration =
+              widget.focusedDecoration?.copyWith(
+            border: Border.all(
+              width: 3.0,
+              color: themeData.brightness.isDark
+                  ? const Color.fromRGBO(26, 169, 255, 0.3)
+                  : const Color.fromRGBO(0, 103, 244, 0.25),
+            ),
+          );
+
+          final focusedPlaceholderDecoration = focusedDecoration?.copyWith(
+            border: () {
+              if (focusedDecoration.border is Border) {
+                BorderSide borderSide(BorderSide fromSide) {
+                  return BorderSide(
+                    color: fromSide.color.withValues(alpha: 0.0),
+                    style: fromSide.style,
+                    width: fromSide.width,
+                  );
+                }
+
+                return Border(
+                  bottom:
+                      borderSide((focusedDecoration.border as Border).bottom),
+                  top: borderSide((focusedDecoration.border as Border).top),
+                  left: borderSide((focusedDecoration.border as Border).left),
+                  right: borderSide((focusedDecoration.border as Border).right),
+                );
               }
-              _requestKeyboard();
-            },
-      child: IgnorePointer(
-        ignoring: !enabled,
-        child: AnimatedContainer(
-          /// Value eyeballed from MacOS Big Sur
-          duration: const Duration(milliseconds: 125),
-          decoration: _effectiveFocusNode.hasFocus
-              ? focusedDecoration
-              : focusedPlaceholderDecoration,
-          child: Container(
-            decoration:
-                _effectiveFocusNode.hasFocus ? null : effectiveDecoration,
-            child: _selectionGestureDetectorBuilder.buildGestureDetector(
-              behavior: HitTestBehavior.translucent,
-              child: Align(
-                alignment: Alignment(-1.0, _textAlignVertical.y),
-                widthFactor: 1.0,
-                heightFactor: 1.0,
-                child: _addTextDependentAttachments(
-                  paddedEditable,
-                  textStyle,
-                  placeholderStyle,
+              return focusedDecoration.border;
+            }(),
+            color: focusedDecoration.color ?? const Color(0x00000000),
+          );
+
+          final Color selectionColor =
+              MacosTheme.of(context).primaryColor.withValues(alpha: 0.2);
+
+          final Widget paddedEditable = Padding(
+            padding: widget.padding,
+            child: RepaintBoundary(
+              child: UnmanagedRestorationScope(
+                bucket: bucket,
+                child: EditableText(
+                  key: editableTextKey,
+                  controller: controller,
+                  readOnly: widget.readOnly,
+                  showCursor: widget.showCursor,
+                  showSelectionHandles: _showSelectionHandles,
+                  focusNode: _effectiveFocusNode,
+                  keyboardType: widget.keyboardType,
+                  textInputAction: widget.textInputAction,
+                  textCapitalization: widget.textCapitalization,
+                  style: textStyle,
+                  strutStyle: widget.strutStyle,
+                  textAlign: widget.textAlign,
+                  autofocus: widget.autofocus,
+                  obscuringCharacter: widget.obscuringCharacter,
+                  obscureText: widget.obscureText,
+                  autocorrect: widget.autocorrect,
+                  smartDashesType: widget.smartDashesType,
+                  smartQuotesType: widget.smartQuotesType,
+                  enableSuggestions: widget.enableSuggestions,
+                  maxLines: widget.maxLines,
+                  minLines: widget.minLines,
+                  expands: widget.expands,
+                  selectionColor: selectionColor,
+                  selectionControls:
+                      widget.selectionEnabled ? textSelectionControls : null,
+                  onChanged: widget.onChanged,
+                  onSelectionChanged: _handleSelectionChanged,
+                  onEditingComplete: widget.onEditingComplete,
+                  onSubmitted: widget.onSubmitted,
+                  inputFormatters: formatters,
+                  rendererIgnoresPointer: true,
+                  cursorWidth: widget.cursorWidth,
+                  cursorHeight: widget.cursorHeight,
+                  cursorRadius: widget.cursorRadius,
+                  cursorColor: cursorColor,
+                  cursorOpacityAnimates: true,
+                  cursorOffset: cursorOffset,
+                  paintCursorAboveText: true,
+                  autocorrectionTextRectColor: selectionColor,
+                  backgroundCursorColor: MacosDynamicColor.resolve(
+                    CupertinoColors.inactiveGray,
+                    context,
+                  ),
+                  selectionHeightStyle: widget.selectionHeightStyle,
+                  selectionWidthStyle: widget.selectionWidthStyle,
+                  scrollPadding: widget.scrollPadding,
+                  keyboardAppearance: keyboardAppearance,
+                  dragStartBehavior: widget.dragStartBehavior,
+                  scrollController: widget.scrollController,
+                  scrollPhysics: widget.scrollPhysics,
+                  enableInteractiveSelection: widget.enableInteractiveSelection,
+                  autofillHints: widget.autofillHints,
+                  restorationId: 'editable',
+                  mouseCursor: SystemMouseCursors.text,
+                  contextMenuBuilder: widget.contextMenuBuilder,
                 ),
               ),
             ),
-          ),
-        ),
-      ),
-    );
+          );
+
+          return Semantics(
+            enabled: enabled,
+            onTap: !enabled || widget.readOnly
+                ? null
+                : () {
+                    if (!controller.selection.isValid) {
+                      controller.selection = TextSelection.collapsed(
+                          offset: controller.text.length);
+                    }
+                    _requestKeyboard();
+                  },
+            child: IgnorePointer(
+              ignoring: !enabled,
+              child: AnimatedContainer(
+                /// Value eyeballed from MacOS Big Sur
+                duration: const Duration(milliseconds: 125),
+                decoration: _effectiveFocusNode.hasFocus
+                    ? focusedDecoration
+                    : focusedPlaceholderDecoration,
+                child: Container(
+                  decoration:
+                      _effectiveFocusNode.hasFocus ? null : effectiveDecoration,
+                  child: _selectionGestureDetectorBuilder.buildGestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    child: Align(
+                      alignment: Alignment(-1.0, _textAlignVertical.y),
+                      widthFactor: 1.0,
+                      heightFactor: 1.0,
+                      child: _addTextDependentAttachments(
+                        paddedEditable,
+                        textStyle,
+                        placeholderStyle,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+        });
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.1.9
+version: 2.1.10
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 


### PR DESCRIPTION
MacosTextField has optional parameter .cursorColor that, if not specified, defaults to simple white or black (#fff, #000) depending on current ThemeMode. 

If the MacosTextField does not _always_ use default theme background color, the default cursor color may not be visible. This requires the dev to code it so if text color is non-default, the cursor color must also be overridden to non-default.

A more sensible fallback for "if not specified, use..." is to match the cursor color to the text. Just blanket forcing black or white is a poor choice when the text color is available to be examined instead.

Example: A writing app, where user can specify text color and background color. The user could be using any text color, on any background color, regardless of whether or no the app itself is in Dark or Light mode. 

This change inserts "check text color" as an option, before giving up and simply choosing black or white with no regard for context.