### PR TITLE
Fixed setState issue in MacosPulldownButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.2.2]
+### 🛠 Fixed 🛠
+- Fixed setState called after dispose issue in MacosPulldownButton.
+
 ## [2.2.1]
 ### 🔄 Updated 🔄
 * Wrap toolbar items with `MacosToolbarPassthrough` to prevent window move or resize when interacting with toolbar items.

--- a/lib/src/buttons/pulldown_button.dart
+++ b/lib/src/buttons/pulldown_button.dart
@@ -835,9 +835,9 @@ class _MacosPulldownButtonState extends State<MacosPulldownButton>
     );
 
     navigator.push(_pulldownRoute!).then<void>((_) {
+      if (!mounted) return;
       setState(() => _pullDownButtonState = PulldownButtonState.enabled);
       _removeMacosPulldownRoute();
-      if (!mounted) return;
     });
 
     widget.onTap?.call();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: macos_ui
 description: Flutter widgets and themes implementing the current macOS design language.
-version: 2.2.1
+version: 2.2.2
 homepage: "https://macosui.dev"
 repository: "https://github.com/GroovinChip/macos_ui"
 

--- a/test/buttons/pulldown_button_test.dart
+++ b/test/buttons/pulldown_button_test.dart
@@ -57,6 +57,48 @@ void main() {
       expect(mockOnPressedFunction.called, 2);
     });
 
+    testWidgets('MacosPulldownButton displays correctly items ',
+            (WidgetTester tester) async {
+          await tester.pumpWidget(MacosApp(
+            home: MacosWindow(
+              child: MacosScaffold(
+                children: [
+                  ContentArea(
+                    builder: (context, _) {
+                      return Center(
+                        child: MacosPulldownButton(
+                          title: "Menu",
+                          items: [
+                            MacosPulldownMenuItem(
+                              title: const Text('New folder'),
+                              onTap: () {},
+                            ),
+                            MacosPulldownMenuItem(
+                              title: const Text('Document'),
+                              onTap: () {},
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ));
+
+          // Verify that the title is rendered on the button.
+          expect(find.text('Menu'), findsOneWidget);
+
+          // tap on the button to open the pulldown menu.
+          await tester.tap(find.text('Menu'));
+          await tester.pumpAndSettle();
+
+          // Verify that the menu items are displayed.
+          expect(find.text('New folder'), findsOneWidget);
+          expect(find.text('Document'), findsOneWidget);
+        });
+
     testWidgets(
       'MacosPulldownButtonItems\' onTap callback is called when defined',
       (WidgetTester tester) async {


### PR DESCRIPTION

### 🔄 Reopened PR

This replaces a previous PR that was closed due to a branch issue.
Reopening with a clean branch and the same fix applied.

---

### 🧩 Fix: avoid calling setState after dispose in MacosPulldownButton

When I used `MacosPulldownButton`, this error appeared during tests:

```
setState() called after dispose(): _MacosPulldownButtonState (lifecycle state: defunct, not mounted)
```

It happened because `setState` was called inside the `navigator.push(...).then(...)` callback after the widget was already disposed.

I fixed it by adding a `mounted` check before calling `setState`:

```dart
navigator.push(_pulldownRoute!).then<void>((_) {
  if (!mounted) return;
  setState(() => _pullDownButtonState = PulldownButtonState.enabled);
  _removeMacosPulldownRoute();
});
```

Thanks for your patience, I’ll be happy to make any additional changes if needed.